### PR TITLE
Fix bug of comment processing

### DIFF
--- a/stmt/parse.go
+++ b/stmt/parse.go
@@ -310,7 +310,7 @@ loop:
 
 			// add space when remaining runes begin with space, and previous
 			// captured word did not
-			if sl := len(s); sl != 0 && IsSpace(r[0]) && !IsSpace(s[sl-1]) {
+			if sl := len(s); sl != 0 && len(r) > 0 && IsSpace(r[0]) && !IsSpace(s[sl-1]) {
 				s = append(s, ' ')
 			}
 


### PR DESCRIPTION
Fix index out of range bug of following trace:

```
panic: runtime error: index out of range

goroutine 43 [running]:
github.com/CovenantSQL/CovenantSQL/vendor/github.com/xo/usql/stmt.findPrefix(0xc00012e1b0, 0x4, 0x5, 0x6, 0x55e2a90, 0x1)
        /Users/xq262144/Documents/Dev/gopath/src/github.com/CovenantSQL/CovenantSQL/vendor/github.com/xo/usql/stmt/parse.go:313 +0xa2f
github.com/CovenantSQL/CovenantSQL/vendor/github.com/xo/usql/stmt.(*Stmt).Next(0xc000290210, 0xc000686010, 0x0, 0x0, 0x0, 0xc000290210, 0xb, 0x0)
        /Users/xq262144/Documents/Dev/gopath/src/github.com/CovenantSQL/CovenantSQL/vendor/github.com/xo/usql/stmt/stmt.go:341 +0x336
github.com/CovenantSQL/CovenantSQL/vendor/github.com/xo/usql/handler.(*Handler).outputHighlighter(0xc00056e000, 0xc000025c20, 0xb, 0xb, 0xc000025c20)
        /Users/xq262144/Documents/Dev/gopath/src/github.com/CovenantSQL/CovenantSQL/vendor/github.com/xo/usql/handler/handler.go:164 +0x383
github.com/CovenantSQL/CovenantSQL/vendor/github.com/xo/usql/handler.(*Handler).outputHighlighter-fm(0xc000025c20, 0xb, 0xb, 0x40)
        /Users/xq262144/Documents/Dev/gopath/src/github.com/CovenantSQL/CovenantSQL/vendor/github.com/xo/usql/handler/handler.go:95 +0x3e
github.com/CovenantSQL/CovenantSQL/vendor/github.com/gohxs/readline.(*RuneBuffer).output(0xc000266480, 0xb, 0xc0004bdd80, 0xe)
        /Users/xq262144/Documents/Dev/gopath/src/github.com/CovenantSQL/CovenantSQL/vendor/github.com/gohxs/readline/runebuf.go:485 +0x25c
github.com/CovenantSQL/CovenantSQL/vendor/github.com/gohxs/readline.(*RuneBuffer).print(0xc000266480)
        /Users/xq262144/Documents/Dev/gopath/src/github.com/CovenantSQL/CovenantSQL/vendor/github.com/gohxs/readline/runebuf.go:452 +0x2b
github.com/CovenantSQL/CovenantSQL/vendor/github.com/gohxs/readline.(*RuneBuffer).Refresh(0xc000266480, 0xc0004bddd0)
        /Users/xq262144/Documents/Dev/gopath/src/github.com/CovenantSQL/CovenantSQL/vendor/github.com/gohxs/readline/runebuf.go:442 +0xb0
github.com/CovenantSQL/CovenantSQL/vendor/github.com/gohxs/readline.(*RuneBuffer).Backspace(0xc000266480)
        /Users/xq262144/Documents/Dev/gopath/src/github.com/CovenantSQL/CovenantSQL/vendor/github.com/gohxs/readline/runebuf.go:340 +0x4e
github.com/CovenantSQL/CovenantSQL/vendor/github.com/gohxs/readline.(*Operation).ioloop(0xc0000a4480)
        /Users/xq262144/Documents/Dev/gopath/src/github.com/CovenantSQL/CovenantSQL/vendor/github.com/gohxs/readline/operation.go:216 +0xd08
created by github.com/CovenantSQL/CovenantSQL/vendor/github.com/gohxs/readline.NewOperation
        /Users/xq262144/Documents/Dev/gopath/src/github.com/CovenantSQL/CovenantSQL/vendor/github.com/gohxs/readline/operation.go:86 +0x2af
```