### PR TITLE
Exit with non-zero code on query errors

### DIFF
--- a/drivers/errors.go
+++ b/drivers/errors.go
@@ -47,6 +47,9 @@ func (e *Error) Error() string {
 	return e.Driver + ": " + chop(e.Err.Error(), e.Driver)
 }
 
+// Unwrap returns the original error
+func (e *Error) Unwrap() error { return e.Err }
+
 // chop chops off a "prefix: " prefix from a string.
 func chop(s, prefix string) string {
 	return strings.TrimLeftFunc(strings.TrimPrefix(strings.TrimSpace(s), prefix+":"), unicode.IsSpace)

--- a/handler/errors.go
+++ b/handler/errors.go
@@ -1,0 +1,25 @@
+package handler
+
+// Error wraps handler errors
+type Error struct {
+	Buf string
+	Err error
+}
+
+// WrapErr wraps an error using the specified driver when err is not nil.
+func WrapErr(buf string, err error) error {
+	if err == nil {
+		return nil
+	}
+	// avoid double wrapping error
+	if _, ok := err.(*Error); ok {
+		return err
+	}
+	return &Error{buf, err}
+}
+
+// Error satisfies the error interface, returning the original error message
+func (e *Error) Error() string { return e.Err.Error() }
+
+// Unwrap returns the original error
+func (e *Error) Unwrap() error { return e.Err }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -197,6 +198,7 @@ func (h *Handler) Run() error {
 		fmt.Fprintln(h.l.Stdout(), text.WelcomeDesc)
 		fmt.Fprintln(h.l.Stdout())
 	}
+	var lastErr error
 	for {
 		var execute bool
 		// set prompt
@@ -212,6 +214,9 @@ func (h *Handler) Run() error {
 			h.buf.Reset(nil)
 			continue
 		case err != nil:
+			if err == io.EOF {
+				return lastErr
+			}
 			return err
 		}
 		var res metacmd.Result
@@ -220,23 +225,23 @@ func (h *Handler) Run() error {
 			// decode
 			var r metacmd.Runner
 			r, err = metacmd.Decode(cmd, params)
-			switch {
-			case err == text.ErrUnknownCommand:
-				fmt.Fprintf(stderr, text.InvalidCommand, cmd)
-				fmt.Fprintln(stderr)
-				continue
-			case err == text.ErrMissingRequiredArgument:
-				fmt.Fprintf(stderr, text.MissingRequiredArg, cmd)
-				fmt.Fprintln(stderr)
-				continue
-			case err != nil:
-				fmt.Fprintf(stderr, "error: %v", err)
+			if err != nil {
+				lastErr = WrapErr(cmd, err)
+				switch {
+				case err == text.ErrUnknownCommand:
+					fmt.Fprintf(stderr, text.InvalidCommand, cmd)
+				case err == text.ErrMissingRequiredArgument:
+					fmt.Fprintf(stderr, text.MissingRequiredArg, cmd)
+				default:
+					fmt.Fprintf(stderr, "error: %v", err)
+				}
 				fmt.Fprintln(stderr)
 				continue
 			}
 			// run
 			res, err = r.Run(h)
 			if err != nil && err != rline.ErrInterrupt {
+				lastErr = WrapErr(cmd, err)
 				fmt.Fprintf(stderr, "error: %v", err)
 				fmt.Fprintln(stderr)
 				continue
@@ -258,12 +263,16 @@ func (h *Handler) Run() error {
 				typ, end, batch := drivers.IsBatchQueryPrefix(h.u, h.buf.Prefix)
 				switch {
 				case h.batch && batch:
-					fmt.Fprintf(stderr, "error: cannot perform %s in existing batch", typ)
+					err = fmt.Errorf("cannot perform %s in existing batch", typ)
+					lastErr = WrapErr(h.buf.String(), err)
+					fmt.Fprintf(stderr, "error: %v", err)
 					fmt.Fprintln(stderr)
 					continue
 				// cannot use \g* while accumulating statements for batch queries
 				case h.batch && typ != h.batchEnd && res.Exec != metacmd.ExecNone:
-					fmt.Fprint(stderr, "error: cannot force batch execution")
+					err = errors.New("cannot force batch execution")
+					lastErr = WrapErr(h.buf.String(), err)
+					fmt.Fprintf(stderr, "error: %v", err)
 					fmt.Fprintln(stderr)
 					continue
 				case batch:
@@ -300,6 +309,7 @@ func (h *Handler) Run() error {
 				}
 				// execute
 				if err = h.Execute(stdout, res, h.lastPrefix, h.last, forceBatch); err != nil {
+					lastErr = WrapErr(h.last, err)
 					fmt.Fprintf(stderr, "error: %v", err)
 					fmt.Fprintln(stderr)
 				}
@@ -942,9 +952,6 @@ func (h *Handler) Include(path string, relative bool) error {
 	p.db, p.u = h.db, h.u
 	drivers.ConfigStmt(p.u, p.buf)
 	err = p.Run()
-	if err == io.EOF {
-		err = nil
-	}
 	h.db, h.u = p.db, p.u
 	return err
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 //go:generate ./gen-license.sh
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -44,8 +45,12 @@ func main() {
 	// run
 	err = run(args, cur)
 	if err != nil && err != io.EOF && err != rline.ErrInterrupt {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		if e, ok := err.(*drivers.Error); ok && e.Err == text.ErrDriverNotAvailable {
+		var he *handler.Error
+		if !errors.As(err, &he) {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		}
+		var e *drivers.Error
+		if errors.As(err, &e) && e.Err == text.ErrDriverNotAvailable {
 			m := make(map[string]string, len(known))
 			for k, v := range known {
 				m[v] = k
@@ -145,7 +150,7 @@ func runCommandOrFiles(h *handler.Handler, commandsOrFiles []CommandOrFile) func
 			h.SetSingleLineMode(x.Command)
 			if x.Command {
 				h.Reset([]rune(x.Value))
-				if err := h.Run(); err != nil && err != io.EOF {
+				if err := h.Run(); err != nil {
 					return err
 				}
 			} else {


### PR DESCRIPTION
Exit with non-zero code on query errors. Makes `handler.Run()` return last command or query error or `nil` if there were none. It now never returns `io.EOF`. `handler.Run()` is the only function that prints errors, so skip printing in `main.go` if a handler error is detected.

Tested with:
```bash
# current master
% usql -W 'pg://postgres@127.0.0.1:5432/test?sslmode=disable' -c "insert into test values (1, 'b')"
Connected with driver postgres (PostgreSQL 13.0 (Debian 13.0-1.pgdg100+1))
error: pq: 23505: duplicate key value violates unique constraint "test_pkey"
% echo $?
0

# this branch
% ./build/linux/0.7.9/usql -W 'pg://postgres@127.0.0.1:5432/test?sslmode=disable' -c "insert into test values (1, 'b')"
Connected with driver postgres (PostgreSQL 13.0 (Debian 13.0-1.pgdg100+1))
error: pq: 23505: duplicate key value violates unique constraint "test_pkey"
% echo $?
1
```

Closes #69