### PR TITLE
Add timing option for queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ Connection
 Operating System
   \cd [DIR]                       change the current working directory
   \setenv NAME [VALUE]            set or unset environment variable
+  \timing [on|off]                toggle timing of commands
   \! [COMMAND]                    execute command in shell or start interactive shell
 
 Variables

--- a/metacmd/metacmd.go
+++ b/metacmd/metacmd.go
@@ -76,4 +76,6 @@ const (
 	Unset
 	// SetFormatVar is the set format variable meta commands (\pset, \a, \C, \f, \H, \t, \T, \x).
 	SetFormatVar
+	// Timing is the timing meta command (\timing).
+	Timing
 )

--- a/metacmd/types.go
+++ b/metacmd/types.go
@@ -48,6 +48,10 @@ type Handler interface {
 	Rollback() error
 	// Highlight highlights the statement.
 	Highlight(io.Writer, string) error
+	// GetTiming mode.
+	GetTiming() bool
+	// SetTiming mode.
+	SetTiming(bool)
 }
 
 // Runner is a runner interface type.

--- a/text/text.go
+++ b/text/text.go
@@ -74,6 +74,8 @@ var (
 		`tableattr`: `Table attributes unset.`,
 		`title`:     `Title is unset.`,
 	}
+	TimingSet = `Timing is %s.`
+	TimingDesc = `Time: %0.3f ms`
 )
 
 func init() {


### PR DESCRIPTION
Add timing option for queries and commands.

In `psql` it looks like:
```
127.0.0.1 postgres@postgres=# \timing on
Timing is on.
127.0.0.1 postgres@postgres=# select count(*) from generate_series(1,100000000);
┌───────────┐
│   count   │
├───────────┤
│ 100000000 │
└───────────┘
(1 row)

Time: 32113.135 ms (00:32.113)
```

In `usql` it would be:
```
pg:postgres@127.0.0.1/test=> \timing
Timing is on.
pg:postgres@127.0.0.1/test=> select count(*) from generate_series(1,100000000);
 count     
-----------
 100000000 
(1 row)

Time: 32851.439 ms (32.851s)
```

I intentionally used the default Go's duration format for >1s to make the code simpler. I believe it serves the purpose of displaying the time in a human-readable way and a deviation from psql like that is acceptable.

Closes #126 