### PR TITLE
Make prompt work in includes

### DIFF
--- a/contrib/postgres/init.sql
+++ b/contrib/postgres/init.sql
@@ -1,12 +1,12 @@
 \set POSTGRES_USER postgres
 \set POSTGRES_PASS P4ssw0rd
 \set POSTGRES_DB   postgres
-\set POSTGRES_HOST `docker port postgres 5432`
+\set POSTGRES_HOST `docker port postgres 5432 | head -n1`
 
 \prompt NAME 'Create database user: '
 \prompt -password PASS 'Password for "':NAME'": '
 
-\connect 'postgres://':POSTGRES_USER':':POSTGRES_PASS'@':POSTGRES_HOST'/':POSTGRES_DB
+\connect 'postgres://':POSTGRES_USER':':POSTGRES_PASS'@':POSTGRES_HOST'/':POSTGRES_DB'?sslmode=disable'
 
 DROP USER IF EXISTS :NAME;
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -650,7 +650,7 @@ func (h *Handler) ReadVar(typ, prompt string) (string, error) {
 		z, err = strconv.ParseBool(v)
 	}
 	if err != nil {
-		return "", text.ErrInvalidValue
+		return "", fmt.Errorf("error: invalid value, %w", err)
 	}
 	return fmt.Sprintf("%v", z), nil
 }
@@ -1005,7 +1005,8 @@ func (h *Handler) Include(path string, relative bool) error {
 		Err: h.l.Stderr(),
 		Pw:  h.l.Password,
 	}
-	p := New(l, h.user, filepath.Dir(path), h.nopw)
+	p := New(h.l, h.user, filepath.Dir(path), h.nopw)
+	p.buf = stmt.New(l.Next)
 	p.db, p.u = h.db, h.u
 	drivers.ConfigStmt(p.u, p.buf)
 	err = p.Run()

--- a/rline/rline.go
+++ b/rline/rline.go
@@ -183,8 +183,16 @@ func New(forceNonInteractive bool, out, histfile string) (IO, error) {
 	}
 	closers = append(closers, l.Close)
 	n := l.Operation.Runes
+	pw := func(prompt string) (string, error) {
+		buf, err := l.ReadPassword(prompt)
+		if err != nil {
+			return "", err
+		}
+		return string(buf), nil
+	}
 	if forceNonInteractive {
 		n = nil
+		pw = nil
 	}
 	return &Rline{
 		Inst: l,
@@ -201,12 +209,6 @@ func New(forceNonInteractive bool, out, histfile string) (IO, error) {
 		Cyg: cygwin,
 		P:   l.SetPrompt,
 		S:   l.SaveHistory,
-		Pw: func(prompt string) (string, error) {
-			buf, err := l.ReadPassword(prompt)
-			if err != nil {
-				return "", err
-			}
-			return string(buf), nil
-		},
+		Pw:  pw,
 	}, nil
 }


### PR DESCRIPTION
Make prompt work in includes by using same IO in the include handler as in the main handler. Only the statement struct is using the included file IO.

Also, disable password prompts in non-interactive mode.