### PR TITLE
SQL Server db metadata reader

### DIFF
--- a/drivers/metadata/informationschema/Dockerfile
+++ b/drivers/metadata/informationschema/Dockerfile
@@ -3,5 +3,6 @@ FROM $BASE_IMAGE
 
 ARG SCHEMA_URL
 ARG TARGET
-ADD $SCHEMA_URL $TARGET/
-RUN [ ! -d "$TARGET" ] || chmod -R 777 $TARGET/
+ARG USER
+ADD --chown=$USER $SCHEMA_URL $TARGET/
+RUN [ ! -d "$TARGET" ] || chmod -R 777 $TARGET/ || echo "failed to change perms of $TARGET, leaving as $(ls -la $TARGET/)"

--- a/drivers/metadata/informationschema/metadata_test.go
+++ b/drivers/metadata/informationschema/metadata_test.go
@@ -8,30 +8,37 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
 
+	_ "github.com/denisenkom/go-mssqldb" // DRIVER: mssql
 	_ "github.com/go-sql-driver/mysql"
 	dt "github.com/ory/dockertest/v3"
 	dc "github.com/ory/dockertest/v3/docker"
 	_ "github.com/trinodb/trino-go-client/trino"
 	"github.com/xo/usql/drivers/metadata"
-	"github.com/xo/usql/drivers/metadata/informationschema"
+	infos "github.com/xo/usql/drivers/metadata/informationschema"
 	_ "github.com/xo/usql/drivers/postgres"
 )
 
 type Database struct {
 	BuildArgs  []dc.BuildArg
 	RunOptions *dt.RunOptions
+	Exec       []string
 	Driver     string
 	URL        string
 	DockerPort string
 	Resource   *dt.Resource
 	DB         *sql.DB
-	Opts       []informationschema.Option
+	Opts       []infos.Option
 	Reader     metadata.BasicReader
 }
+
+const (
+	pw = "yourStrong123_Password"
+)
 
 var (
 	dbs = map[string]*Database{
@@ -40,6 +47,7 @@ var (
 				{Name: "BASE_IMAGE", Value: "postgres:13"},
 				{Name: "SCHEMA_URL", Value: "https://raw.githubusercontent.com/jOOQ/jOOQ/main/jOOQ-examples/Sakila/postgres-sakila-db/postgres-sakila-schema.sql"},
 				{Name: "TARGET", Value: "/docker-entrypoint-initdb.d"},
+				{Name: "USER", Value: "root"},
 			},
 			RunOptions: &dt.RunOptions{
 				Name: "usql-pgsql",
@@ -49,8 +57,12 @@ var (
 			Driver:     "postgres",
 			URL:        "postgres://postgres:pw@localhost:%s/postgres?sslmode=disable",
 			DockerPort: "5432/tcp",
-			Opts: []informationschema.Option{
-				informationschema.WithIndexes(false),
+			Opts: []infos.Option{
+				infos.WithIndexes(false),
+				infos.WithCustomColumns(map[infos.ColumnName]string{
+					infos.ColumnsColumnSize:         "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
+					infos.FunctionColumnsColumnSize: "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
+				}),
 			},
 		},
 		"mysql": {
@@ -58,6 +70,7 @@ var (
 				{Name: "BASE_IMAGE", Value: "mysql:8"},
 				{Name: "SCHEMA_URL", Value: "https://raw.githubusercontent.com/jOOQ/jOOQ/main/jOOQ-examples/Sakila/mysql-sakila-db/mysql-sakila-schema.sql"},
 				{Name: "TARGET", Value: "/docker-entrypoint-initdb.d"},
+				{Name: "USER", Value: "root"},
 			},
 			RunOptions: &dt.RunOptions{
 				Name: "usql-mysql",
@@ -67,8 +80,34 @@ var (
 			Driver:     "mysql",
 			URL:        "root:pw@(localhost:%s)/mysql?parseTime=true",
 			DockerPort: "3306/tcp",
-			Opts: []informationschema.Option{
-				informationschema.WithPlaceholder(func(int) string { return "?" }),
+			Opts: []infos.Option{
+				infos.WithPlaceholder(func(int) string { return "?" }),
+				infos.WithCustomColumns(map[infos.ColumnName]string{
+					infos.ColumnsNumericPrecRadix:         "10",
+					infos.FunctionColumnsNumericPrecRadix: "10",
+				}),
+			},
+		},
+		"mssql": {
+			BuildArgs: []dc.BuildArg{
+				{Name: "BASE_IMAGE", Value: "mcr.microsoft.com/mssql/server:2019-latest"},
+				{Name: "SCHEMA_URL", Value: "https://raw.githubusercontent.com/jOOQ/jOOQ/main/jOOQ-examples/Sakila/sql-server-sakila-db/sql-server-sakila-schema.sql"},
+				{Name: "TARGET", Value: "/schema"},
+				{Name: "USER", Value: "mssql:0"},
+			},
+			RunOptions: &dt.RunOptions{
+				Name: "usql-mssql",
+				Env:  []string{"ACCEPT_EULA=Y", "SA_PASSWORD=" + pw},
+			},
+			Exec:       []string{"/opt/mssql-tools/bin/sqlcmd", "-S", "localhost", "-U", "sa", "-P", pw, "-d", "master", "-i", "/schema/sql-server-sakila-schema.sql"},
+			Driver:     "mssql",
+			URL:        "sqlserver://sa:" + url.QueryEscape(pw) + "@127.0.0.1:%s?database=sakila",
+			DockerPort: "1433/tcp",
+			Opts: []infos.Option{
+				infos.WithIndexes(false),
+				infos.WithCustomColumns(map[infos.ColumnName]string{
+					infos.FunctionsSecurityType: "''",
+				}),
 			},
 		},
 		"trino": {
@@ -81,9 +120,19 @@ var (
 			Driver:     "trino",
 			URL:        "http://test@localhost:%s?catalog=tpch&schema=sf1",
 			DockerPort: "8080/tcp",
-			Opts: []informationschema.Option{
-				informationschema.WithTypeDetails(false),
-				informationschema.WithPlaceholder(func(int) string { return "?" }),
+			Opts: []infos.Option{
+				infos.WithPlaceholder(func(int) string { return "?" }),
+				infos.WithIndexes(false),
+				infos.WithCustomColumns(map[infos.ColumnName]string{
+					infos.ColumnsColumnSize:               "0",
+					infos.ColumnsNumericScale:             "0",
+					infos.ColumnsNumericPrecRadix:         "0",
+					infos.ColumnsCharOctetLength:          "0",
+					infos.FunctionColumnsColumnSize:       "0",
+					infos.FunctionColumnsNumericScale:     "0",
+					infos.FunctionColumnsNumericPrecRadix: "0",
+					infos.FunctionColumnsCharOctetLength:  "0",
+				}),
 			},
 		},
 	}
@@ -91,8 +140,23 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	var only string
 	flag.BoolVar(&cleanup, "cleanup", true, "delete containers when finished")
+	flag.StringVar(&only, "dbs", "", "comma separated list of dbs to test: pgsql, mysql, mssql, trino")
 	flag.Parse()
+
+	if only != "" {
+		runOnly := map[string]struct{}{}
+		for _, dbName := range strings.Split(only, ",") {
+			dbName = strings.TrimSpace(dbName)
+			runOnly[dbName] = struct{}{}
+		}
+		for dbName := range dbs {
+			if _, ok := runOnly[dbName]; !ok {
+				delete(dbs, dbName)
+			}
+		}
+	}
 
 	pool, err := dt.NewPool("")
 	if err != nil {
@@ -115,27 +179,30 @@ func TestMain(m *testing.M) {
 
 		// exponential backoff-retry, because the application in the container might not be ready to accept connections yet
 		if err := pool.Retry(func() error {
+			hostPort := db.Resource.GetPort(db.DockerPort)
 			var err error
-			db.DB, err = sql.Open(db.Driver, fmt.Sprintf(db.URL, db.Resource.GetPort(db.DockerPort)))
+			db.DB, err = sql.Open(db.Driver, fmt.Sprintf(db.URL, hostPort))
 			if err != nil {
 				return err
 			}
 			return db.DB.Ping()
 		}); err != nil {
-			log.Fatal("Could not connect to docker: ", err)
+			log.Fatal("Timed out waiting for db: ", err)
 		}
-		db.Reader = informationschema.New(db.Opts...)(db.DB).(metadata.BasicReader)
+		db.Reader = infos.New(db.Opts...)(db.DB).(metadata.BasicReader)
+
+		if len(db.Exec) != 0 {
+			exitCode, err := db.Resource.Exec(db.Exec, dt.ExecOptions{
+				StdIn:  os.Stdin,
+				StdOut: os.Stdout,
+				StdErr: os.Stderr,
+				TTY:    true,
+			})
+			if err != nil || exitCode != 0 {
+				log.Fatal("Could not load schema: ", err)
+			}
+		}
 	}
-	//exitCode, err := resource.Exec([]string{"psql", "-f", "/postgres-sakila-schema.sql"}, dt.ExecOptions{
-	//	StdIn:  os.Stdin,
-	//	StdOut: os.Stdout,
-	//	StdErr: os.Stderr,
-	//	TTY:    true,
-	//	Env:    []string{"PGUSER=postgres", "PGPASSWORD=pw"},
-	//})
-	//if err != nil || exitCode != 0 {
-	//	log.Fatal("Could not load schema: ", err)
-	//}
 
 	code := m.Run()
 
@@ -155,6 +222,7 @@ func TestSchemas(t *testing.T) {
 	expected := map[string]string{
 		"pgsql": "information_schema, pg_catalog, pg_toast, public",
 		"mysql": "information_schema, mysql, performance_schema, sakila, sys",
+		"mssql": "db_accessadmin, db_backupoperator, db_datareader, db_datawriter, db_ddladmin, db_denydatareader, db_denydatawriter, db_owner, db_securityadmin, dbo, guest, INFORMATION_SCHEMA, sys",
 		"trino": "information_schema, sf1, sf100, sf1000, sf10000, sf100000, sf300, sf3000, sf30000, tiny",
 	}
 	for dbName, db := range dbs {
@@ -180,11 +248,13 @@ func TestTables(t *testing.T) {
 	schemas := map[string]string{
 		"pgsql": "public",
 		"mysql": "sakila",
+		"mssql": "dbo",
 		"trino": "sf1",
 	}
 	expected := map[string]string{
 		"pgsql": "actor, address, category, city, country, customer, film, film_actor, film_category, inventory, language, payment, payment_p2007_01, payment_p2007_02, payment_p2007_03, payment_p2007_04, payment_p2007_05, payment_p2007_06, rental, staff, store, actor_info, customer_list, film_list, nicer_but_slower_film_list, sales_by_film_category, sales_by_store, staff_list",
 		"mysql": "actor, address, category, city, country, customer, film, film_actor, film_category, film_text, inventory, language, payment, rental, staff, store, actor_info, customer_list, film_list, nicer_but_slower_film_list, sales_by_film_category, sales_by_store, staff_list",
+		"mssql": "actor, address, category, city, country, customer, film, film_actor, film_category, film_text, inventory, language, payment, rental, staff, store, customer_list, film_list, sales_by_film_category, sales_by_store, staff_list",
 		"trino": "customer, lineitem, nation, orders, part, partsupp, region, supplier",
 	}
 	for dbName, db := range dbs {
@@ -210,16 +280,19 @@ func TestColumns(t *testing.T) {
 	schemas := map[string]string{
 		"pgsql": "public",
 		"mysql": "sakila",
+		"mssql": "dbo",
 		"trino": "sf1",
 	}
 	tables := map[string]string{
 		"pgsql": "film%",
 		"mysql": "film%",
+		"mssql": "film%",
 		"trino": "orders",
 	}
 	expected := map[string]string{
 		"pgsql": "film_id, title, description, release_year, language_id, original_language_id, rental_duration, rental_rate, length, replacement_cost, rating, last_update, special_features, fulltext, actor_id, film_id, last_update, film_id, category_id, last_update, fid, title, description, category, price, length, rating, actors",
 		"mysql": "film_id, title, description, release_year, language_id, original_language_id, rental_duration, rental_rate, length, replacement_cost, rating, special_features, last_update, actor_id, film_id, last_update, film_id, category_id, last_update, FID, title, description, category, price, length, rating, actors, film_id, title, description",
+		"mssql": "film_id, title, description, release_year, language_id, original_language_id, rental_duration, rental_rate, length, replacement_cost, rating, special_features, last_update, actor_id, film_id, last_update, film_id, category_id, last_update, FID, title, description, category, price, length, rating, actors, film_id, title, description",
 		"trino": "orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment",
 	}
 	for dbName, db := range dbs {
@@ -254,7 +327,7 @@ func TestFunctions(t *testing.T) {
 		if schemas[dbName] == "" {
 			continue
 		}
-		r := informationschema.New(db.Opts...)(db.DB).(metadata.FunctionReader)
+		r := infos.New(db.Opts...)(db.DB).(metadata.FunctionReader)
 
 		result, err := r.Functions("", schemas[dbName], "", []string{})
 		if err != nil {
@@ -289,7 +362,7 @@ func TestFunctionColumns(t *testing.T) {
 		if schemas[dbName] == "" {
 			continue
 		}
-		r := informationschema.New(db.Opts...)(db.DB).(metadata.FunctionColumnReader)
+		r := infos.New(db.Opts...)(db.DB).(metadata.FunctionColumnReader)
 
 		result, err := r.FunctionColumns("", schemas[dbName], tables[dbName])
 		if err != nil {
@@ -318,7 +391,7 @@ func TestIndexes(t *testing.T) {
 		if schemas[dbName] == "" {
 			continue
 		}
-		r := informationschema.New(db.Opts...)(db.DB).(metadata.IndexReader)
+		r := infos.New(db.Opts...)(db.DB).(metadata.IndexReader)
 
 		result, err := r.Indexes("", schemas[dbName], "", "")
 		if err != nil {
@@ -350,7 +423,7 @@ func TestIndexColumns(t *testing.T) {
 		if schemas[dbName] == "" {
 			continue
 		}
-		r := informationschema.New(db.Opts...)(db.DB).(metadata.IndexColumnReader)
+		r := infos.New(db.Opts...)(db.DB).(metadata.IndexColumnReader)
 
 		result, err := r.IndexColumns("", schemas[dbName], "", tables[dbName])
 		if err != nil {
@@ -379,7 +452,7 @@ func TestSequences(t *testing.T) {
 		if schemas[dbName] == "" {
 			continue
 		}
-		r := informationschema.New(db.Opts...)(db.DB).(metadata.SequenceReader)
+		r := infos.New(db.Opts...)(db.DB).(metadata.SequenceReader)
 
 		result, err := r.Sequences("", schemas[dbName], "")
 		if err != nil {

--- a/drivers/metadata/testdata/pgsql.descTable.expected.txt
+++ b/drivers/metadata/testdata/pgsql.descTable.expected.txt
@@ -1,15 +1,15 @@
 BASE TABLE "public.film"
  Name                 | Type                        | Nullable | Default                               | Size | Decimal Digits | Radix | Octet Length 
 ----------------------+-----------------------------+----------+---------------------------------------+------+----------------+-------+--------------
- film_id              | integer                     | "NO"     | nextval('film_film_id_seq'::regclass) |   32 |              0 |    10 |            0 
+ film_id              | integer                     | "NO"     | nextval('film_film_id_seq'::regclass) |   32 |              0 |     2 |            0 
  title                | character varying           | "NO"     |                                       |  255 |              0 |    10 |         1020 
  description          | text                        | "YES"    |                                       |    0 |              0 |    10 |   1073741824 
- release_year         | integer                     | "YES"    |                                       |   32 |              0 |    10 |            0 
- language_id          | smallint                    | "NO"     |                                       |   16 |              0 |    10 |            0 
- original_language_id | smallint                    | "YES"    |                                       |   16 |              0 |    10 |            0 
- rental_duration      | smallint                    | "NO"     | 3                                     |   16 |              0 |    10 |            0 
+ release_year         | integer                     | "YES"    |                                       |   32 |              0 |     2 |            0 
+ language_id          | smallint                    | "NO"     |                                       |   16 |              0 |     2 |            0 
+ original_language_id | smallint                    | "YES"    |                                       |   16 |              0 |     2 |            0 
+ rental_duration      | smallint                    | "NO"     | 3                                     |   16 |              0 |     2 |            0 
  rental_rate          | numeric                     | "NO"     | 4.99                                  |    4 |              2 |    10 |            0 
- length               | smallint                    | "YES"    |                                       |   16 |              0 |    10 |            0 
+ length               | smallint                    | "YES"    |                                       |   16 |              0 |     2 |            0 
  replacement_cost     | numeric                     | "NO"     | 19.99                                 |    5 |              2 |    10 |            0 
  rating               | USER-DEFINED                | "YES"    | 'G'::mpaa_rating                      |    0 |              0 |    10 |            0 
  last_update          | timestamp without time zone | "NO"     | now()                                 |    6 |              0 |    10 |            0 
@@ -20,28 +20,28 @@ BASE TABLE "public.film"
 BASE TABLE "public.film_actor"
  Name        | Type                        | Nullable | Default | Size | Decimal Digits | Radix | Octet Length 
 -------------+-----------------------------+----------+---------+------+----------------+-------+--------------
- actor_id    | smallint                    | "NO"     |         |   16 |              0 |    10 |            0 
- film_id     | smallint                    | "NO"     |         |   16 |              0 |    10 |            0 
+ actor_id    | smallint                    | "NO"     |         |   16 |              0 |     2 |            0 
+ film_id     | smallint                    | "NO"     |         |   16 |              0 |     2 |            0 
  last_update | timestamp without time zone | "NO"     | now()   |    6 |              0 |    10 |            0 
 (3 rows)
 
 BASE TABLE "public.film_category"
  Name        | Type                        | Nullable | Default | Size | Decimal Digits | Radix | Octet Length 
 -------------+-----------------------------+----------+---------+------+----------------+-------+--------------
- film_id     | smallint                    | "NO"     |         |   16 |              0 |    10 |            0 
- category_id | smallint                    | "NO"     |         |   16 |              0 |    10 |            0 
+ film_id     | smallint                    | "NO"     |         |   16 |              0 |     2 |            0 
+ category_id | smallint                    | "NO"     |         |   16 |              0 |     2 |            0 
  last_update | timestamp without time zone | "NO"     | now()   |    6 |              0 |    10 |            0 
 (3 rows)
 
 VIEW "public.film_list"
  Name        | Type              | Nullable | Default | Size | Decimal Digits | Radix | Octet Length 
 -------------+-------------------+----------+---------+------+----------------+-------+--------------
- fid         | integer           | "YES"    |         |   32 |              0 |    10 |            0 
+ fid         | integer           | "YES"    |         |   32 |              0 |     2 |            0 
  title       | character varying | "YES"    |         |  255 |              0 |    10 |         1020 
  description | text              | "YES"    |         |    0 |              0 |    10 |   1073741824 
  category    | character varying | "YES"    |         |   25 |              0 |    10 |          100 
  price       | numeric           | "YES"    |         |    4 |              2 |    10 |            0 
- length      | smallint          | "YES"    |         |   16 |              0 |    10 |            0 
+ length      | smallint          | "YES"    |         |   16 |              0 |     2 |            0 
  rating      | USER-DEFINED      | "YES"    |         |    0 |              0 |    10 |            0 
  actors      | text              | "YES"    |         |    0 |              0 |    10 |   1073741824 
 (8 rows)

--- a/drivers/mssql/mssql.go
+++ b/drivers/mssql/mssql.go
@@ -15,13 +15,19 @@ import (
 )
 
 func init() {
-	newReader := infos.New(
-		infos.WithIndexes(false),
-		infos.WithSequences(false),
-		infos.WithCustomColumns(map[infos.ColumnName]string{
-			infos.FunctionsSecurityType: "''",
-		}),
-	)
+	newReader := func(db drivers.DB) metadata.Reader {
+		ir := infos.New(
+			infos.WithIndexes(false),
+			infos.WithSequences(false),
+			infos.WithCustomColumns(map[infos.ColumnName]string{
+				infos.FunctionsSecurityType: "''",
+			}),
+		)(db)
+		mr := &metaReader{
+			db: db,
+		}
+		return metadata.NewPluginReader(ir, mr)
+	}
 	drivers.Register("mssql", drivers.Driver{
 		AllowMultilineComments:  true,
 		RequirePreviousPassword: true,

--- a/drivers/mssql/reader.go
+++ b/drivers/mssql/reader.go
@@ -1,0 +1,152 @@
+package mssql
+
+import (
+	"strings"
+
+	"github.com/xo/usql/drivers"
+	"github.com/xo/usql/drivers/metadata"
+)
+
+type metaReader struct {
+	db drivers.DB
+}
+
+func (r metaReader) Catalogs() (*metadata.CatalogSet, error) {
+	qstr := `
+SELECT name
+FROM sys.databases
+ORDER BY name
+`
+
+	rows, err := r.db.Query(qstr)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []metadata.Catalog{}
+	for rows.Next() {
+		rec := metadata.Catalog{}
+		err = rows.Scan(&rec.Catalog)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, rec)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	return metadata.NewCatalogSet(results), nil
+}
+
+func (r metaReader) Indexes(catalog, schemaPattern, tablePattern, namePattern string) (*metadata.IndexSet, error) {
+	qstr := `
+SELECT
+  db_name(),
+  s.name,
+  t.name,
+  COALESCE(i.name, ''),
+  CASE WHEN i.is_primary_key = 1 THEN 'YES' ELSE 'NO' END,
+  CASE WHEN i.is_unique = 1 THEN 'YES' ELSE 'NO' END,
+  i.type_desc
+FROM sys.schemas s
+JOIN sys.tables t on t.schema_id = s.schema_id
+JOIN sys.indexes i ON i.object_id = t.object_id
+`
+	conds := []string{}
+	vals := []interface{}{}
+	if schemaPattern != "" {
+		vals = append(vals, schemaPattern)
+		conds = append(conds, "s.name LIKE ?")
+	}
+	if tablePattern != "" {
+		vals = append(vals, tablePattern)
+		conds = append(conds, "t.name LIKE ?")
+	}
+	if namePattern != "" {
+		vals = append(vals, namePattern)
+		conds = append(conds, "i.name LIKE ?")
+	}
+	if len(conds) != 0 {
+		qstr += " WHERE " + strings.Join(conds, " AND ")
+	}
+	qstr += `
+ORDER BY s.name, t.name, i.name`
+
+	rows, err := r.db.Query(qstr, vals...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []metadata.Index{}
+	for rows.Next() {
+		rec := metadata.Index{}
+		err = rows.Scan(&rec.Catalog, &rec.Schema, &rec.Table, &rec.Name, &rec.IsUnique, &rec.IsPrimary, &rec.Type)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, rec)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	return metadata.NewIndexSet(results), nil
+}
+
+func (r metaReader) IndexColumns(catalog, schemaPattern, tablePattern, indexPattern string) (*metadata.IndexColumnSet, error) {
+	qstr := `
+SELECT
+  db_name(),
+  s.name,
+  t.name,
+  COALESCE(i.name, ''),
+  c.name,
+  t.name,
+  ic.key_ordinal
+FROM sys.schemas s
+JOIN sys.tables t on t.schema_id = s.schema_id
+JOIN sys.indexes i ON i.object_id = t.object_id
+JOIN sys.index_columns ic ON i.object_id = ic.object_id and i.index_id = ic.index_id
+JOIN sys.columns c ON ic.object_id = c.object_id and ic.column_id = c.column_id
+JOIN sys.types ty ON ty.user_type_id = c.user_type_id
+`
+	conds := []string{}
+	vals := []interface{}{}
+	if schemaPattern != "" {
+		vals = append(vals, schemaPattern)
+		conds = append(conds, "s.name LIKE ?")
+	}
+	if tablePattern != "" {
+		vals = append(vals, tablePattern)
+		conds = append(conds, "t.name LIKE ?")
+	}
+	if indexPattern != "" {
+		vals = append(vals, indexPattern)
+		conds = append(conds, "i.name LIKE ?")
+	}
+	if len(conds) != 0 {
+		qstr += " WHERE " + strings.Join(conds, " AND ")
+	}
+	qstr += `
+ORDER BY s.name, t.name, i.name, ic.index_column_id`
+	rows, err := r.db.Query(qstr, vals...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []metadata.IndexColumn{}
+	for rows.Next() {
+		rec := metadata.IndexColumn{}
+		err = rows.Scan(&rec.Catalog, &rec.Schema, &rec.Table, &rec.IndexName, &rec.Name, &rec.DataType, &rec.OrdinalPosition)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, rec)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	return metadata.NewIndexColumnSet(results), nil
+}

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -10,13 +10,17 @@ import (
 	"github.com/go-sql-driver/mysql" // DRIVER: mysql
 	"github.com/xo/usql/drivers"
 	"github.com/xo/usql/drivers/metadata"
-	"github.com/xo/usql/drivers/metadata/informationschema"
+	infos "github.com/xo/usql/drivers/metadata/informationschema"
 )
 
 func init() {
-	newReader := informationschema.New(
-		informationschema.WithPlaceholder(func(int) string { return "?" }),
-		informationschema.WithSequences(false),
+	newReader := infos.New(
+		infos.WithPlaceholder(func(int) string { return "?" }),
+		infos.WithSequences(false),
+		infos.WithCustomColumns(map[infos.ColumnName]string{
+			infos.ColumnsNumericPrecRadix:         "10",
+			infos.FunctionColumnsNumericPrecRadix: "10",
+		}),
 	)
 	drivers.Register("mysql", drivers.Driver{
 		AllowMultilineComments: true,

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -10,13 +10,17 @@ import (
 	"github.com/xo/dburl"
 	"github.com/xo/usql/drivers"
 	"github.com/xo/usql/drivers/metadata"
-	"github.com/xo/usql/drivers/metadata/informationschema"
+	infos "github.com/xo/usql/drivers/metadata/informationschema"
 )
 
 func init() {
 	newReader := func(db drivers.DB) metadata.Reader {
-		ir := informationschema.New(
-			informationschema.WithIndexes(false),
+		ir := infos.New(
+			infos.WithIndexes(false),
+			infos.WithCustomColumns(map[infos.ColumnName]string{
+				infos.ColumnsColumnSize:         "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
+				infos.FunctionColumnsColumnSize: "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
+			}),
 		)(db)
 		mr := &metaReader{
 			db: db,

--- a/drivers/postgres/reader.go
+++ b/drivers/postgres/reader.go
@@ -55,8 +55,6 @@ FROM pg_catalog.pg_class c
      LEFT JOIN pg_catalog.pg_index i ON i.indexrelid = c.oid
      LEFT JOIN pg_catalog.pg_class c2 ON i.indrelid = c2.oid
 WHERE c.relkind IN ('i','I','')
-      AND n.nspname <> 'pg_catalog'
-      AND n.nspname <> 'information_schema'
       AND n.nspname !~ '^pg_toast'
   AND pg_catalog.pg_table_is_visible(c.oid)
 `

--- a/drivers/trino/trino.go
+++ b/drivers/trino/trino.go
@@ -11,18 +11,23 @@ import (
 	"github.com/xo/tblfmt"
 	"github.com/xo/usql/drivers"
 	"github.com/xo/usql/drivers/metadata"
-	"github.com/xo/usql/drivers/metadata/informationschema"
+	infos "github.com/xo/usql/drivers/metadata/informationschema"
 	"github.com/xo/usql/env"
 )
 
 func init() {
 	endRE := regexp.MustCompile(`;?\s*$`)
-	newReader := informationschema.New(
-		informationschema.WithPlaceholder(func(int) string { return "?" }),
-		informationschema.WithTypeDetails(false),
-		informationschema.WithFunctions(false),
-		informationschema.WithSequences(false),
-		informationschema.WithIndexes(false),
+	newReader := infos.New(
+		infos.WithPlaceholder(func(int) string { return "?" }),
+		infos.WithCustomColumns(map[infos.ColumnName]string{
+			infos.ColumnsColumnSize:       "0",
+			infos.ColumnsNumericScale:     "0",
+			infos.ColumnsNumericPrecRadix: "0",
+			infos.ColumnsCharOctetLength:  "0",
+		}),
+		infos.WithFunctions(false),
+		infos.WithSequences(false),
+		infos.WithIndexes(false),
 	)
 	drivers.Register("trino", drivers.Driver{
 		AllowMultilineComments: true,


### PR DESCRIPTION
Implement SQL Server db metadata reader using the reader from the `informationschema` module. ~~It doesn't list indexes.~~ Obviously, like PostgreSQL, this would benefit from a dedicated reader using the `sys` schema, but this should be a good start.

There was _one_ column missing in the functions table. I added a map for custom column expressions, fixing a few other issues, like lack of `numeric_precision_radix` and `interval_precision` in mysql. This will also allow using aggregates to fetch column names for indexes (and relations, when we add them) in fewer queries.

Closes #173 