### PR TITLE
Oracle db metadata reader

### DIFF
--- a/drivers/godror/godror.go
+++ b/drivers/godror/godror.go
@@ -7,12 +7,17 @@ package godror
 import (
 	"database/sql"
 	"fmt"
+	"io"
+	"log"
+	"os"
 	"regexp"
 	"strings"
 
 	_ "github.com/godror/godror" // DRIVER: godror
 	"github.com/xo/dburl"
 	"github.com/xo/usql/drivers"
+	"github.com/xo/usql/drivers/metadata"
+	orameta "github.com/xo/usql/drivers/metadata/oracle"
 	"github.com/xo/usql/env"
 	"golang.org/x/xerrors"
 )
@@ -104,6 +109,24 @@ func init() {
 			sqlstr = endRE.ReplaceAllString(sqlstr, "")
 			typ, q := drivers.QueryExecType(prefix, sqlstr)
 			return typ, sqlstr, q, nil
+		},
+		NewMetadataReader: orameta.NewReader(),
+		NewMetadataWriter: func(db drivers.DB, w io.Writer) metadata.Writer {
+			// TODO if options would be common to all readers, this could be moved
+			// to the caller and passed in an argument
+			envs := env.All()
+			opts := []orameta.Option{}
+			if envs["ECHO_HIDDEN"] == "on" || envs["ECHO_HIDDEN"] == "noexec" {
+				if envs["ECHO_HIDDEN"] == "noexec" {
+					opts = append(opts, orameta.WithDryRun(true))
+				}
+				opts = append(opts, orameta.WithLogger(log.New(os.Stdout, "DEBUG: ", log.LstdFlags)))
+			}
+			newReader := orameta.NewReader(opts...)
+			writerOpts := []metadata.Option{
+				metadata.WithSystemSchemas([]string{"ctxsys", "flows_files", "mdsys", "outln", "sys", "system", "xdb", "xs$null"}),
+			}
+			return metadata.NewDefaultWriter(newReader(db), writerOpts...)(db, w)
 		},
 	})
 }

--- a/drivers/godror/godror.go
+++ b/drivers/godror/godror.go
@@ -8,8 +8,6 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
-	"log"
-	"os"
 	"regexp"
 	"strings"
 
@@ -111,22 +109,11 @@ func init() {
 			return typ, sqlstr, q, nil
 		},
 		NewMetadataReader: orameta.NewReader(),
-		NewMetadataWriter: func(db drivers.DB, w io.Writer) metadata.Writer {
-			// TODO if options would be common to all readers, this could be moved
-			// to the caller and passed in an argument
-			envs := env.All()
-			opts := []orameta.Option{}
-			if envs["ECHO_HIDDEN"] == "on" || envs["ECHO_HIDDEN"] == "noexec" {
-				if envs["ECHO_HIDDEN"] == "noexec" {
-					opts = append(opts, orameta.WithDryRun(true))
-				}
-				opts = append(opts, orameta.WithLogger(log.New(os.Stdout, "DEBUG: ", log.LstdFlags)))
-			}
-			newReader := orameta.NewReader(opts...)
-			writerOpts := []metadata.Option{
+		NewMetadataWriter: func(db drivers.DB, w io.Writer, opts ...metadata.ReaderOption) metadata.Writer {
+			writerOpts := []metadata.WriterOption{
 				metadata.WithSystemSchemas([]string{"ctxsys", "flows_files", "mdsys", "outln", "sys", "system", "xdb", "xs$null"}),
 			}
-			return metadata.NewDefaultWriter(newReader(db), writerOpts...)(db, w)
+			return metadata.NewDefaultWriter(orameta.NewReader()(db, opts...), writerOpts...)(db, w)
 		},
 	})
 }

--- a/drivers/metadata/metadata_test.go
+++ b/drivers/metadata/metadata_test.go
@@ -59,7 +59,7 @@ var (
 					infos.FunctionColumnsColumnSize: "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
 				}),
 			},
-			WriterOpts: []metadata.Option{
+			WriterOpts: []metadata.WriterOption{
 				metadata.WithSystemSchemas([]string{"pg_catalog", "pg_toast", "information_schema"}),
 			},
 		},
@@ -86,7 +86,7 @@ var (
 					infos.FunctionColumnsNumericPrecRadix: "10",
 				}),
 			},
-			WriterOpts: []metadata.Option{
+			WriterOpts: []metadata.WriterOption{
 				metadata.WithSystemSchemas([]string{"mysql", "performance_schema", "information_schema"}),
 			},
 		},

--- a/drivers/metadata/oracle/metadata.go
+++ b/drivers/metadata/oracle/metadata.go
@@ -1,0 +1,522 @@
+// Package oracle provides a metadata reader
+package oracle
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/xo/usql/drivers"
+	"github.com/xo/usql/drivers/metadata"
+)
+
+type metaReader struct {
+	db     drivers.DB
+	logger Logger
+	dryRun bool
+}
+
+type Logger interface {
+	Println(...interface{})
+}
+
+func NewReader(opts ...Option) func(db drivers.DB) metadata.Reader {
+	r := &metaReader{}
+	for _, o := range opts {
+		o(r)
+	}
+	return func(db drivers.DB) metadata.Reader {
+		r.db = db
+		return r
+	}
+}
+
+// Option to configure the reader
+type Option func(*metaReader)
+
+func WithLogger(l Logger) Option {
+	return func(r *metaReader) {
+		r.logger = l
+	}
+}
+
+func WithDryRun(d bool) Option {
+	return func(r *metaReader) {
+		r.dryRun = d
+	}
+}
+
+func (r metaReader) Catalogs() (*metadata.CatalogSet, error) {
+	qstr := `SELECT
+  UPPER(Value) AS catalog
+FROM v$parameter o
+WHERE name = 'db_name'
+UNION ALL
+SELECT
+  db_link AS catalog
+FROM dba_db_links
+ORDER BY catalog
+`
+
+	rows, err := r.query(qstr)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return metadata.NewCatalogSet([]metadata.Catalog{}), nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []metadata.Catalog{}
+	for rows.Next() {
+		rec := metadata.Catalog{}
+		err = rows.Scan(&rec.Catalog)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, rec)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	return metadata.NewCatalogSet(results), nil
+}
+
+func (r metaReader) Schemas(catalog, namePattern string) (*metadata.SchemaSet, error) {
+	qstr := `SELECT
+  username
+FROM all_users
+`
+	conds := []string{}
+	vals := []interface{}{}
+	if namePattern != "" {
+		vals = append(vals, namePattern)
+		conds = append(conds, "username LIKE %s")
+	}
+	if len(conds) != 0 {
+		qstr += " WHERE " + strings.Join(conds, " AND ")
+	}
+	qstr += `
+ORDER BY username`
+	rows, err := r.query(qstr, vals...)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return metadata.NewSchemaSet([]metadata.Schema{}), nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []metadata.Schema{}
+	for rows.Next() {
+		rec := metadata.Schema{}
+		err = rows.Scan(&rec.Schema)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, rec)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	return metadata.NewSchemaSet(results), nil
+}
+
+// Tables from selected catalog (or all, if empty), matching schemas, names and types
+func (r metaReader) Tables(catalog, schemaPattern, namePattern string, types []string) (*metadata.TableSet, error) {
+	qstr := `SELECT
+o.owner AS table_schem,
+o.object_name AS table_name,
+o.object_type AS table_type
+FROM all_objects o
+`
+	conds := []string{}
+	vals := []interface{}{}
+	if schemaPattern != "" {
+		vals = append(vals, schemaPattern)
+		conds = append(conds, fmt.Sprintf("o.owner LIKE :%d", len(vals)))
+	}
+	if namePattern != "" {
+		vals = append(vals, namePattern)
+		conds = append(conds, fmt.Sprintf("o.object_name LIKE :%d", len(vals)))
+	}
+	addSynonyms := false
+	if len(types) != 0 {
+		pholders := []string{}
+		for _, t := range types {
+			if t == "SYNONYM" {
+				addSynonyms = true
+			}
+			vals = append(vals, t)
+			pholders = append(pholders, fmt.Sprintf(":%d", len(vals)))
+		}
+		if len(pholders) != 0 {
+			conds = append(conds, "o.object_type IN ("+strings.Join(pholders, ", ")+")")
+		}
+	}
+	if len(conds) != 0 {
+		qstr += " WHERE " + strings.Join(conds, " AND ")
+	}
+	if addSynonyms {
+		qstr += `
+UNION ALL
+SELECT
+  s.owner AS table_schem,
+  s.synonym_name AS table_name,
+  'SYNONYM' AS table_type
+FROM all_synonyms s
+`
+		conds = []string{}
+		if schemaPattern != "" {
+			vals = append(vals, schemaPattern)
+			conds = append(conds, fmt.Sprintf("s.owner LIKE :%d", len(vals)))
+		}
+		if namePattern != "" {
+			vals = append(vals, namePattern)
+			conds = append(conds, fmt.Sprintf("s.synonym_name LIKE :%d", len(vals)))
+		}
+		if len(conds) != 0 {
+			qstr += " WHERE " + strings.Join(conds, " AND ")
+		}
+	}
+	qstr += `
+ORDER BY table_schem, table_name, table_type`
+	rows, err := r.query(qstr, vals...)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return metadata.NewTableSet([]metadata.Table{}), nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []metadata.Table{}
+	for rows.Next() {
+		rec := metadata.Table{}
+		err = rows.Scan(&rec.Schema, &rec.Name, &rec.Type)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, rec)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	return metadata.NewTableSet(results), nil
+}
+
+func (r metaReader) Columns(catalog, schemaPattern, tablePattern string) (*metadata.ColumnSet, error) {
+	qstr := `SELECT
+  c.owner,
+  c.table_name,
+  c.column_name,
+  c.column_id AS ordinal_position,
+  c.data_type,
+  CASE c.nullable
+    WHEN 'Y' THEN 'YES'
+    ELSE  'NO'  END AS nullable,
+  COALESCE(c.data_length, c.data_precision, 0),
+  COALESCE(c.data_scale, 0),
+  CASE c.data_type
+           WHEN 'FLOAT'  THEN  2
+           WHEN 'NUMBER' THEN 10
+  ELSE  0  END AS num_prec_radix,
+  COALESCE(c.char_col_decl_length, 0) as char_octet_length
+FROM all_tab_columns c
+`
+	conds := []string{}
+	vals := []interface{}{}
+	if schemaPattern != "" {
+		vals = append(vals, schemaPattern)
+		conds = append(conds, fmt.Sprintf("c.owner LIKE :%d", len(vals)))
+	}
+	if tablePattern != "" {
+		vals = append(vals, tablePattern)
+		conds = append(conds, fmt.Sprintf("c.table_name LIKE :%d", len(vals)))
+	}
+	if len(conds) != 0 {
+		qstr += " WHERE " + strings.Join(conds, " AND ")
+	}
+	qstr += `
+ORDER BY c.owner, c.table_name, c.column_id`
+	rows, err := r.query(qstr, vals...)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return metadata.NewColumnSet([]metadata.Column{}), nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []metadata.Column{}
+	for rows.Next() {
+		rec := metadata.Column{}
+		targets := []interface{}{
+			&rec.Schema,
+			&rec.Table,
+			&rec.Name,
+			&rec.OrdinalPosition,
+			&rec.DataType,
+			&rec.IsNullable,
+			&rec.ColumnSize,
+			&rec.DecimalDigits,
+			&rec.NumPrecRadix,
+			&rec.CharOctetLength,
+		}
+		err = rows.Scan(targets...)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, rec)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	return metadata.NewColumnSet(results), nil
+}
+
+func (r metaReader) Functions(catalog, schemaPattern, namePattern string, types []string) (*metadata.FunctionSet, error) {
+	qstr := `SELECT
+  decode (b.object_type,'PACKAGE',CONCAT(CONCAT(b.object_name,'.'), a.object_name)
+         ,b.object_name) as specific_name,
+  b.owner   as procedure_schem,
+  decode (b.object_type,'PACKAGE',CONCAT(CONCAT(b.object_name,'.'), a.object_name)
+         ,b.object_name) as procedure_name,
+  decode (b.object_type,'PACKAGE',decode(a.position,0,2,1,1,0),
+          decode(b.object_type,'PROCEDURE',1,'FUNCTION',2,0)) as procedure_type
+FROM all_arguments a
+JOIN all_objects b ON b.object_id = a.object_id AND a.sequence  = 1
+`
+	conds := []string{"(b.object_type = 'PROCEDURE' OR b.object_type = 'FUNCTION' OR b.object_type = 'PACKAGE')"}
+	vals := []interface{}{}
+	if schemaPattern != "" {
+		vals = append(vals, schemaPattern)
+		conds = append(conds, fmt.Sprintf("b.owner LIKE :%d", len(vals)))
+	}
+	if namePattern != "" {
+		vals = append(vals, namePattern)
+		conds = append(conds, fmt.Sprintf("b.object_name LIKE :%d", len(vals)))
+	}
+	if len(types) != 0 {
+		pholders := []string{}
+		for _, t := range types {
+			vals = append(vals, t)
+			pholders = append(pholders, fmt.Sprintf(":%d", len(vals)))
+		}
+		if len(pholders) != 0 {
+			conds = append(conds, "b.object_type IN ("+strings.Join(pholders, ", ")+")")
+		}
+	}
+	if len(conds) != 0 {
+		qstr += " WHERE " + strings.Join(conds, " AND ")
+	}
+	qstr += `
+ORDER BY procedure_schem, procedure_name, procedure_type`
+	rows, err := r.query(qstr, vals...)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return metadata.NewFunctionSet([]metadata.Function{}), nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []metadata.Function{}
+	for rows.Next() {
+		rec := metadata.Function{}
+		err = rows.Scan(
+			&rec.SpecificName,
+			&rec.Schema,
+			&rec.Name,
+			&rec.Type,
+		)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, rec)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	return metadata.NewFunctionSet(results), nil
+}
+
+func (r metaReader) FunctionColumns(catalog, schemaPattern, functionPattern string) (*metadata.FunctionColumnSet, error) {
+	qstr := `SELECT
+     a.owner   as procedure_schem,
+     decode (b.object_type,'PACKAGE',CONCAT(CONCAT(b.object_name,'.'),a.object_name),
+             b.object_name) as procedure_name,
+     decode(a.position,0,'RETURN_VALUE',a.argument_name) as column_name,
+     a.position       as ordinal_position,
+     decode(a.position,0,5,decode(a.in_out,'IN',1,'IN/OUT',2,'OUT',4)) as column_type,
+     a.data_type      as type_name,
+     COALESCE(a.data_length, a.data_precision, 0) as column_size,
+     COALESCE(a.data_scale, 0) as decimal_digits,
+     COALESCE(a.radix, 0) as num_prec_radix
+FROM all_objects b
+JOIN all_arguments a ON b.object_id = a.object_id AND a.data_level = 0
+`
+	conds := []string{"b.object_type = 'PROCEDURE' OR b.object_type = 'FUNCTION'"}
+	vals := []interface{}{}
+	if schemaPattern != "" {
+		vals = append(vals, schemaPattern)
+		conds = append(conds, fmt.Sprintf("a.owner LIKE :%d", len(vals)))
+	}
+	if functionPattern != "" {
+		vals = append(vals, functionPattern)
+		conds = append(conds, fmt.Sprintf("b.object_name LIKE :%d", len(vals)))
+	}
+	if len(conds) != 0 {
+		qstr += " WHERE " + strings.Join(conds, " AND ")
+	}
+	qstr += `
+ORDER BY procedure_schem, procedure_name, ordinal_position`
+	rows, err := r.query(qstr, vals...)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return metadata.NewFunctionColumnSet([]metadata.FunctionColumn{}), nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []metadata.FunctionColumn{}
+	for rows.Next() {
+		rec := metadata.FunctionColumn{}
+		err = rows.Scan(
+			&rec.Schema,
+			&rec.FunctionName,
+			&rec.Name,
+			&rec.OrdinalPosition,
+			&rec.Type,
+			&rec.DataType,
+			&rec.ColumnSize,
+			&rec.DecimalDigits,
+			&rec.NumPrecRadix,
+		)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, rec)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	return metadata.NewFunctionColumnSet(results), nil
+}
+
+func (r metaReader) Indexes(catalog, schemaPattern, tablePattern, namePattern string) (*metadata.IndexSet, error) {
+	qstr := `SELECT
+  o.owner,
+  o.table_name,
+  o.index_name,
+  decode(o.uniqueness,'UNIQUE','NO','YES')
+FROM all_indexes o
+`
+	conds := []string{}
+	vals := []interface{}{}
+	if schemaPattern != "" {
+		vals = append(vals, schemaPattern)
+		conds = append(conds, fmt.Sprintf("o.owner LIKE :%d", len(vals)))
+	}
+	if tablePattern != "" {
+		vals = append(vals, tablePattern)
+		conds = append(conds, fmt.Sprintf("o.table_name LIKE :%d", len(vals)))
+	}
+	if namePattern != "" {
+		vals = append(vals, namePattern)
+		conds = append(conds, fmt.Sprintf("o.index_name LIKE :%d", len(vals)))
+	}
+	if len(conds) != 0 {
+		qstr += " WHERE " + strings.Join(conds, " AND ")
+	}
+	qstr += `
+ORDER BY o.owner, o.table_name, o.index_name`
+
+	rows, err := r.query(qstr, vals...)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return metadata.NewIndexSet([]metadata.Index{}), nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []metadata.Index{}
+	for rows.Next() {
+		rec := metadata.Index{}
+		err = rows.Scan(&rec.Schema, &rec.Table, &rec.Name, &rec.IsUnique)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, rec)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	return metadata.NewIndexSet(results), nil
+}
+
+func (r metaReader) IndexColumns(catalog, schemaPattern, tablePattern, indexPattern string) (*metadata.IndexColumnSet, error) {
+	qstr := `SELECT
+  o.owner,
+  o.table_name,
+  o.index_name,
+  b.column_name,
+  b.column_position
+FROM all_indexes o
+JOIN all_ind_columns b ON o.owner = b.index_owner AND o.index_name = b.index_name
+`
+	conds := []string{}
+	vals := []interface{}{}
+	if schemaPattern != "" {
+		vals = append(vals, schemaPattern)
+		conds = append(conds, fmt.Sprintf("o.owner LIKE :%d", len(vals)))
+	}
+	if tablePattern != "" {
+		vals = append(vals, tablePattern)
+		conds = append(conds, fmt.Sprintf("o.table_name LIKE :%d", len(vals)))
+	}
+	if indexPattern != "" {
+		vals = append(vals, indexPattern)
+		conds = append(conds, fmt.Sprintf("o.index_name LIKE :%d", len(vals)))
+	}
+	if len(conds) != 0 {
+		qstr += " WHERE " + strings.Join(conds, " AND ")
+	}
+	qstr += `
+ORDER BY o.owner, o.table_name, o.index_name, b.column_position`
+	rows, err := r.query(qstr, vals...)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return metadata.NewIndexColumnSet([]metadata.IndexColumn{}), nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := []metadata.IndexColumn{}
+	for rows.Next() {
+		rec := metadata.IndexColumn{}
+		err = rows.Scan(&rec.Schema, &rec.Table, &rec.IndexName, &rec.Name, &rec.OrdinalPosition)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, rec)
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	return metadata.NewIndexColumnSet(results), nil
+}
+
+func (r metaReader) query(q string, v ...interface{}) (*sql.Rows, error) {
+	if r.logger != nil {
+		r.logger.Println(q)
+		r.logger.Println(v)
+	}
+	if r.dryRun {
+		return nil, sql.ErrNoRows
+	}
+	return r.db.Query(q, v...)
+}

--- a/drivers/metadata/writer.go
+++ b/drivers/metadata/writer.go
@@ -35,7 +35,7 @@ type DefaultWriter struct {
 
 var _ Writer = &DefaultWriter{}
 
-func NewDefaultWriter(r Reader, opts ...Option) func(db DB, w io.Writer) Writer {
+func NewDefaultWriter(r Reader, opts ...WriterOption) func(db DB, w io.Writer) Writer {
 	defaultWriter := &DefaultWriter{
 		r: r,
 		tableTypes: map[rune][]string{
@@ -65,11 +65,11 @@ func NewDefaultWriter(r Reader, opts ...Option) func(db DB, w io.Writer) Writer 
 	}
 }
 
-// Option to configure the DefaultWriter
-type Option func(*DefaultWriter)
+// WriterOption to configure the DefaultWriter
+type WriterOption func(*DefaultWriter)
 
 // WithSystemSchemas that are ignored unless showSystem is true
-func WithSystemSchemas(schemas []string) Option {
+func WithSystemSchemas(schemas []string) WriterOption {
 	return func(w *DefaultWriter) {
 		w.systemSchemas = make(map[string]struct{}, len(schemas))
 		for _, s := range schemas {
@@ -79,7 +79,7 @@ func WithSystemSchemas(schemas []string) Option {
 }
 
 // WithListAllDbs that lists all catalogs
-func WithListAllDbs(f func(string, bool) error) Option {
+func WithListAllDbs(f func(string, bool) error) WriterOption {
 	return func(w *DefaultWriter) {
 		w.listAllDbs = f
 	}

--- a/drivers/metadata/writer.go
+++ b/drivers/metadata/writer.go
@@ -39,7 +39,7 @@ func NewDefaultWriter(r Reader, opts ...Option) func(db DB, w io.Writer) Writer 
 	defaultWriter := &DefaultWriter{
 		r: r,
 		tableTypes: map[rune][]string{
-			't': {"TABLE", "BASE TABLE", "SYSTEM TABLE", "LOCAL TEMPORARY", "GLOBAL TEMPORARY"},
+			't': {"TABLE", "BASE TABLE", "SYSTEM TABLE", "SYNONYM", "LOCAL TEMPORARY", "GLOBAL TEMPORARY"},
 			'v': {"VIEW"},
 			'm': {"MATERIALIZED VIEW"},
 			's': {"SEQUENCE"},
@@ -47,7 +47,7 @@ func NewDefaultWriter(r Reader, opts ...Option) func(db DB, w io.Writer) Writer 
 		funcTypes: map[rune][]string{
 			'a': {"AGGREGATE"},
 			'n': {"FUNCTION"},
-			'p': {"PROCEDURE"},
+			'p': {"PROCEDURE", "PACKAGE"},
 			't': {"TRIGGER"},
 			'w': {"WINDOW"},
 		},

--- a/drivers/mssql/reader.go
+++ b/drivers/mssql/reader.go
@@ -3,12 +3,11 @@ package mssql
 import (
 	"strings"
 
-	"github.com/xo/usql/drivers"
 	"github.com/xo/usql/drivers/metadata"
 )
 
 type metaReader struct {
-	db drivers.DB
+	metadata.LoggingReader
 }
 
 func (r metaReader) Catalogs() (*metadata.CatalogSet, error) {
@@ -18,7 +17,7 @@ FROM sys.databases
 ORDER BY name
 `
 
-	rows, err := r.db.Query(qstr)
+	rows, err := r.Query(qstr)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +72,7 @@ JOIN sys.indexes i ON i.object_id = t.object_id
 	qstr += `
 ORDER BY s.name, t.name, i.name`
 
-	rows, err := r.db.Query(qstr, vals...)
+	rows, err := r.Query(qstr, vals...)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +129,7 @@ JOIN sys.types ty ON ty.user_type_id = c.user_type_id
 	}
 	qstr += `
 ORDER BY s.name, t.name, i.name, ic.index_column_id`
-	rows, err := r.db.Query(qstr, vals...)
+	rows, err := r.Query(qstr, vals...)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -5,26 +5,23 @@ package mysql
 
 import (
 	"io"
-	"log"
-	"os"
 	"strconv"
 
 	"github.com/go-sql-driver/mysql" // DRIVER: mysql
 	"github.com/xo/usql/drivers"
 	"github.com/xo/usql/drivers/metadata"
 	infos "github.com/xo/usql/drivers/metadata/informationschema"
-	"github.com/xo/usql/env"
 )
 
 func init() {
-	readerOpts := []infos.Option{
+	newReader := infos.New(
 		infos.WithPlaceholder(func(int) string { return "?" }),
 		infos.WithSequences(false),
 		infos.WithCustomColumns(map[infos.ColumnName]string{
 			infos.ColumnsNumericPrecRadix:         "10",
 			infos.FunctionColumnsNumericPrecRadix: "10",
 		}),
-	}
+	)
 	drivers.Register("mysql", drivers.Driver{
 		AllowMultilineComments: true,
 		AllowHashComments:      true,
@@ -46,23 +43,12 @@ func init() {
 			}
 			return false
 		},
-		NewMetadataReader: infos.New(readerOpts...),
-		NewMetadataWriter: func(db drivers.DB, w io.Writer) metadata.Writer {
-			opts := append([]infos.Option{}, readerOpts...)
-			// TODO if options would be common to all readers, this could be moved
-			// to the caller and passed in an argument
-			envs := env.All()
-			if envs["ECHO_HIDDEN"] == "on" || envs["ECHO_HIDDEN"] == "noexec" {
-				if envs["ECHO_HIDDEN"] == "noexec" {
-					opts = append(opts, infos.WithDryRun(true))
-				}
-				opts = append(opts, infos.WithLogger(log.New(os.Stdout, "DEBUG: ", log.LstdFlags)))
-			}
-			reader := infos.New(opts...)(db)
-			writerOpts := []metadata.Option{
+		NewMetadataReader: newReader,
+		NewMetadataWriter: func(db drivers.DB, w io.Writer, opts ...metadata.ReaderOption) metadata.Writer {
+			writerOpts := []metadata.WriterOption{
 				metadata.WithSystemSchemas([]string{"mysql", "information_schema", "performance_schema"}),
 			}
-			return metadata.NewDefaultWriter(reader, writerOpts...)(db, w)
+			return metadata.NewDefaultWriter(newReader(db, opts...), writerOpts...)(db, w)
 		},
 	}, "memsql", "vitess", "tidb")
 }

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -5,23 +5,26 @@ package mysql
 
 import (
 	"io"
+	"log"
+	"os"
 	"strconv"
 
 	"github.com/go-sql-driver/mysql" // DRIVER: mysql
 	"github.com/xo/usql/drivers"
 	"github.com/xo/usql/drivers/metadata"
 	infos "github.com/xo/usql/drivers/metadata/informationschema"
+	"github.com/xo/usql/env"
 )
 
 func init() {
-	newReader := infos.New(
+	readerOpts := []infos.Option{
 		infos.WithPlaceholder(func(int) string { return "?" }),
 		infos.WithSequences(false),
 		infos.WithCustomColumns(map[infos.ColumnName]string{
 			infos.ColumnsNumericPrecRadix:         "10",
 			infos.FunctionColumnsNumericPrecRadix: "10",
 		}),
-	)
+	}
 	drivers.Register("mysql", drivers.Driver{
 		AllowMultilineComments: true,
 		AllowHashComments:      true,
@@ -43,13 +46,23 @@ func init() {
 			}
 			return false
 		},
-		NewMetadataReader: newReader,
+		NewMetadataReader: infos.New(readerOpts...),
 		NewMetadataWriter: func(db drivers.DB, w io.Writer) metadata.Writer {
-			reader := newReader(db)
-			opts := []metadata.Option{
+			opts := append([]infos.Option{}, readerOpts...)
+			// TODO if options would be common to all readers, this could be moved
+			// to the caller and passed in an argument
+			envs := env.All()
+			if envs["ECHO_HIDDEN"] == "on" || envs["ECHO_HIDDEN"] == "noexec" {
+				if envs["ECHO_HIDDEN"] == "noexec" {
+					opts = append(opts, infos.WithDryRun(true))
+				}
+				opts = append(opts, infos.WithLogger(log.New(os.Stdout, "DEBUG: ", log.LstdFlags)))
+			}
+			reader := infos.New(opts...)(db)
+			writerOpts := []metadata.Option{
 				metadata.WithSystemSchemas([]string{"mysql", "information_schema", "performance_schema"}),
 			}
-			return metadata.NewDefaultWriter(reader, opts...)(db, w)
+			return metadata.NewDefaultWriter(reader, writerOpts...)(db, w)
 		},
 	}, "memsql", "vitess", "tidb")
 }

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -5,24 +5,29 @@ package postgres
 
 import (
 	"io"
-	"log"
-	"os"
 
 	"github.com/lib/pq" // DRIVER: postgres
 	"github.com/xo/dburl"
 	"github.com/xo/usql/drivers"
 	"github.com/xo/usql/drivers/metadata"
 	infos "github.com/xo/usql/drivers/metadata/informationschema"
-	"github.com/xo/usql/env"
 )
 
 func init() {
-	readerOpts := []infos.Option{
-		infos.WithIndexes(false),
-		infos.WithCustomColumns(map[infos.ColumnName]string{
-			infos.ColumnsColumnSize:         "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
-			infos.FunctionColumnsColumnSize: "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
-		}),
+	newReader := func(db drivers.DB, opts ...metadata.ReaderOption) metadata.Reader {
+		newIS := infos.New(
+			infos.WithIndexes(false),
+			infos.WithCustomColumns(map[infos.ColumnName]string{
+				infos.ColumnsColumnSize:         "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
+				infos.FunctionColumnsColumnSize: "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
+			}),
+		)
+		return metadata.NewPluginReader(
+			newIS(db, opts...),
+			&metaReader{
+				LoggingReader: metadata.NewLoggingReader(db, opts...),
+			},
+		)
 	}
 	drivers.Register("postgres", drivers.Driver{
 		Name:                   "pq",
@@ -60,32 +65,12 @@ func init() {
 			}
 			return false
 		},
-		NewMetadataReader: func(db drivers.DB) metadata.Reader {
-			return metadata.NewPluginReader(
-				infos.New(readerOpts...)(db),
-				&metaReader{db: db},
-			)
-		},
-		NewMetadataWriter: func(db drivers.DB, w io.Writer) metadata.Writer {
-			opts := append([]infos.Option{}, readerOpts...)
-			// TODO if options would be common to all readers, this could be moved
-			// to the caller and passed in an argument
-			envs := env.All()
-			if envs["ECHO_HIDDEN"] == "on" || envs["ECHO_HIDDEN"] == "noexec" {
-				if envs["ECHO_HIDDEN"] == "noexec" {
-					opts = append(opts, infos.WithDryRun(true))
-				}
-				opts = append(opts, infos.WithLogger(log.New(os.Stdout, "DEBUG: ", log.LstdFlags)))
-			}
-			reader := metadata.NewPluginReader(
-				infos.New(opts...)(db),
-				// TODO this reader doesn't get logger options applied
-				&metaReader{db: db},
-			)
-			writerOpts := []metadata.Option{
+		NewMetadataReader: newReader,
+		NewMetadataWriter: func(db drivers.DB, w io.Writer, opts ...metadata.ReaderOption) metadata.Writer {
+			writerOpts := []metadata.WriterOption{
 				metadata.WithSystemSchemas([]string{"pg_catalog", "pg_toast", "information_schema"}),
 			}
-			return metadata.NewDefaultWriter(reader, writerOpts...)(db, w)
+			return metadata.NewDefaultWriter(newReader(db, opts...), writerOpts...)(db, w)
 		},
 	}, "cockroachdb", "redshift")
 }

--- a/drivers/sqlite3/reader.go
+++ b/drivers/sqlite3/reader.go
@@ -3,12 +3,11 @@ package sqlite3
 import (
 	"strings"
 
-	"github.com/xo/usql/drivers"
 	"github.com/xo/usql/drivers/metadata"
 )
 
 type metaReader struct {
-	db drivers.DB
+	metadata.LoggingReader
 }
 
 // Columns from selected catalog (or all, if empty), matching schemas and tables
@@ -27,7 +26,7 @@ func (r metaReader) Columns(catalog, schemaPattern, tablePattern string) (*metad
   CASE WHEN "notnull" = 1 THEN 'NO' ELSE 'YES' END,
   COALESCE(dflt_value, '')
 FROM pragma_table_info(?)`
-		rows, err := r.db.Query(qstr, table.Name)
+		rows, err := r.Query(qstr, table.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -118,7 +117,7 @@ FROM (
 	}
 	qstr += `
 ORDER BY table_type, table_name`
-	rows, err := r.db.Query(qstr, vals...)
+	rows, err := r.Query(qstr, vals...)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +155,7 @@ FROM pragma_database_list
 	}
 	qstr += `
 ORDER BY seq`
-	rows, err := r.db.Query(qstr, vals...)
+	rows, err := r.Query(qstr, vals...)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +204,7 @@ FROM pragma_function_list
 	}
 	qstr += `
 ORDER BY name, type`
-	rows, err := r.db.Query(qstr, vals...)
+	rows, err := r.Query(qstr, vals...)
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +258,7 @@ JOIN pragma_index_list(m.name) i
 	qstr += `
 ORDER BY m.name, i.seq`
 
-	rows, err := r.db.Query(qstr, vals...)
+	rows, err := r.Query(qstr, vals...)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +305,7 @@ JOIN pragma_index_xinfo(i.name) ic
 	qstr += `
 ORDER BY m.name, i.seq, ic.seqno`
 
-	rows, err := r.db.Query(qstr, vals...)
+	rows, err := r.Query(qstr, vals...)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -14,9 +14,9 @@ import (
 )
 
 func init() {
-	newReader := func(db drivers.DB) metadata.Reader {
+	newReader := func(db drivers.DB, opts ...metadata.ReaderOption) metadata.Reader {
 		return &metaReader{
-			db: db,
+			LoggingReader: metadata.NewLoggingReader(db, opts...),
 		}
 	}
 	drivers.Register("sqlite3", drivers.Driver{


### PR DESCRIPTION
Implement Oracle metadata reader. Since it's used by two drivers, I've put it into a standalone module.

Since there's a ton of schemas, and Oracle's catalogs are terribly slow to read, I tried implementing dynamic filtering to skip all of them except the one matching the current user. This has a somehow surprising effect where you don't get any results unless you use commands like `\dtS sometable%`. I thought it's an issue with binding params, lost 3 hours staring at the screen, and implemented support for `ECHO_HIDDEN` setting. I went ahead and added it for all readers, since it will be _very_ useful for debugging.

We need to circle back around filtering out system objects. Doing this in the writer is ok-ish for most databases, but too late or Oracle. I should probably remove it for Oracle completely.

Closes #174  and closes #153 