### PR TITLE
Basic context-based autocomplete

### DIFF
--- a/drivers/completer/completer.go
+++ b/drivers/completer/completer.go
@@ -1,0 +1,749 @@
+// completer package provides a generic SQL command line completer
+package completer
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/gohxs/readline"
+	"github.com/xo/usql/drivers/metadata"
+	"github.com/xo/usql/env"
+)
+
+const (
+	WORD_BREAKS = "\t\n@$><=;|&{() "
+)
+
+type caseType bool
+
+var (
+	IGNORE_CASE = caseType(true)
+	MATCH_CASE  = caseType(false)
+)
+
+func NewDefaultCompleter(r metadata.Reader) func(db metadata.DB) readline.AutoCompleter {
+	return func(db metadata.DB) readline.AutoCompleter {
+		return completer{
+			db:     db,
+			reader: r,
+			logger: log.New(os.Stdout, "ERROR: ", log.LstdFlags),
+			sqlStartCommands: []string{
+				"ABORT",
+				"ALTER",
+				"ANALYZE",
+				"BEGIN",
+				"CALL",
+				"CHECKPOINT",
+				"CLOSE",
+				"CLUSTER",
+				"COMMENT",
+				"COMMIT",
+				"COPY",
+				"CREATE",
+				"DEALLOCATE",
+				"DECLARE",
+				"DELETE FROM",
+				"DESC",
+				"DESCRIBE",
+				"DISCARD",
+				"DO",
+				"DROP",
+				"END",
+				"EXEC",
+				"EXECUTE",
+				"EXPLAIN",
+				"FETCH",
+				"GRANT",
+				"IMPORT",
+				"INSERT",
+				"LIST",
+				"LISTEN",
+				"LOAD",
+				"LOCK",
+				"MOVE",
+				"NOTIFY",
+				"PRAGMA",
+				"PREPARE",
+				"REASSIGN",
+				"REFRESH MATERIALIZED VIEW",
+				"REINDEX",
+				"RELEASE",
+				"RESET",
+				"REVOKE",
+				"ROLLBACK",
+				"SAVEPOINT",
+				"SECURITY LABEL",
+				"SELECT",
+				"SET",
+				"SHOW",
+				"START",
+				"TABLE",
+				"TRUNCATE",
+				"UNLISTEN",
+				"UPDATE",
+				"VACUUM",
+				"VALUES",
+				"WITH",
+			},
+			// TODO do we need to add built-in functions like, COALESCE, CAST, NULLIF, CONCAT etc?
+			sqlCommands: []string{
+				"AND",
+				"CASE",
+				"CROSS JOIN",
+				"ELSE",
+				"END",
+				"FETCH",
+				"FROM",
+				"FULL OUTER JOIN",
+				"GROUP BY",
+				"HAVING",
+				"IN",
+				"INNER JOIN",
+				"IS NOT NULL",
+				"IS NULL",
+				"JOIN",
+				"LEFT JOIN",
+				"LIMIT",
+				"NOT",
+				"ON",
+				"OR",
+				"ORDER BY",
+				"THEN",
+				"WHEN",
+				"WHERE",
+			},
+			backslashCommands: []string{
+				`\!`,
+				`\?`,
+				`\a`,
+				`\begin`,
+				`\c`,
+				`\c`,
+				`\C`,
+				`\cd`,
+				`\commit`,
+				`\conninfo`,
+				`\copyright`,
+				`\d+`,
+				`\da+`,
+				`\da`,
+				`\daS+`,
+				`\daS`,
+				`\df+`,
+				`\df`,
+				`\dfS+`,
+				`\dfS`,
+				`\di+`,
+				`\di`,
+				`\diS+`,
+				`\diS`,
+				`\dm+`,
+				`\dm`,
+				`\dmS+`,
+				`\dmS`,
+				`\dn+`,
+				`\dn`,
+				`\dnS+`,
+				`\dnS`,
+				`\drivers`,
+				`\ds+`,
+				`\ds`,
+				`\dS+`,
+				`\dS`,
+				`\dsS+`,
+				`\dsS`,
+				`\dt+`,
+				`\dt`,
+				`\dtS+`,
+				`\dtS`,
+				`\dv+`,
+				`\dv`,
+				`\dvS+`,
+				`\dvS`,
+				`\e`,
+				`\echo`,
+				`\f`,
+				`\g`,
+				`\gexec`,
+				`\gset`,
+				`\gx`,
+				`\H`,
+				`\i`,
+				`\ir`,
+				`\l+`,
+				`\l`,
+				`\p`,
+				`\password`,
+				`\prompt`,
+				`\pset`,
+				`\q`,
+				`\r`,
+				`\raw`,
+				`\rollback`,
+				`\set`,
+				`\setenv`,
+				`\t`,
+				`\T`,
+				`\timing`,
+				`\unset`,
+				`\w`,
+				`\x`,
+				`\Z`,
+			},
+		}
+	}
+}
+
+// completer based on https://github.com/postgres/postgres/blob/9f3665fbfc34b963933e51778c7feaa8134ac885/src/bin/psql/tab-complete.c
+type completer struct {
+	db                metadata.DB
+	reader            metadata.Reader
+	logger            logger
+	sqlStartCommands  []string
+	sqlCommands       []string
+	backslashCommands []string
+}
+
+type logger interface {
+	Println(...interface{})
+}
+
+func (c completer) Do(line []rune, start int) (newLine [][]rune, length int) {
+	var i int
+	for i = start - 1; i > 0; i-- {
+		if strings.ContainsRune(WORD_BREAKS, line[i]) {
+			i++
+			break
+		}
+	}
+	text := line[i:start]
+
+	result := c.complete(getPreviousWords(start, line), text)
+	if result == nil {
+		return nil, 0
+	}
+	return result, len(text)
+}
+
+func (c completer) complete(previousWords []string, text []rune) [][]rune {
+	if len(text) > 0 {
+		if len(previousWords) == 0 && text[0] == '\\' {
+			/* If current word is a backslash command, offer completions for that */
+			return completeFromListCase(MATCH_CASE, text, c.backslashCommands...)
+		}
+		if text[0] == ':' {
+			if len(text) == 1 || text[1] == ':' {
+				return nil
+			}
+			/* If current word is a variable interpolation, handle that case */
+			if text[1] == '\'' {
+				return completeFromVariables(text, ":'", "'", true)
+			}
+			if text[1] == '"' {
+				return completeFromVariables(text, ":\"", "\"", true)
+			}
+			return completeFromVariables(text, ":", "", true)
+		}
+	}
+	if len(previousWords) == 0 {
+		/* If no previous word, suggest one of the basic sql commands */
+		return completeFromList(text, c.sqlStartCommands...)
+	}
+	/* DELETE --- can be inside EXPLAIN, RULE, etc */
+	/* ... despite which, only complete DELETE with FROM at start of line */
+	if matches(IGNORE_CASE, previousWords, "DELETE") {
+		return completeFromList(text, "FROM")
+	}
+	/* Complete DELETE FROM with a list of tables */
+	if tailMatches(IGNORE_CASE, previousWords, "DELETE", "FROM") {
+		return c.completeWithUpdatables(text)
+	}
+	/* Complete DELETE FROM <table> */
+	if tailMatches(IGNORE_CASE, previousWords, "DELETE", "FROM", "*") {
+		return completeFromList(text, "USING", "WHERE")
+	}
+	/* XXX: implement tab completion for DELETE ... USING */
+
+	/* INSERT --- can be inside EXPLAIN, RULE, etc */
+	/* Complete INSERT with "INTO" */
+	if tailMatches(IGNORE_CASE, previousWords, "INSERT") {
+		return completeFromList(text, "INTO")
+	}
+	/* Complete INSERT INTO with table names */
+	if tailMatches(IGNORE_CASE, previousWords, "INSERT", "INTO") {
+		return c.completeWithUpdatables(text)
+	}
+	/* Complete "INSERT INTO <table> (" with attribute names */
+	if tailMatches(IGNORE_CASE, previousWords, "INSERT", "INTO", "*", "(") {
+		return c.completeWithAttributes(IGNORE_CASE, previousWords[1], text)
+	}
+
+	/*
+	 * Complete INSERT INTO <table> with "(" or "VALUES" or "SELECT" or
+	 * "TABLE" or "DEFAULT VALUES" or "OVERRIDING"
+	 */
+	if tailMatches(IGNORE_CASE, previousWords, "INSERT", "INTO", "*") {
+		return completeFromList(text, "(", "DEFAULT VALUES", "SELECT", "TABLE", "VALUES", "OVERRIDING")
+	}
+
+	/*
+	 * Complete INSERT INTO <table> (attribs) with "VALUES" or "SELECT" or
+	 * "TABLE" or "OVERRIDING"
+	 */
+	if tailMatches(IGNORE_CASE, previousWords, "INSERT", "INTO", "*", "*") &&
+		strings.HasSuffix(previousWords[0], ")") {
+		return completeFromList(text, "SELECT", "TABLE", "VALUES", "OVERRIDING")
+	}
+
+	/* Complete OVERRIDING */
+	if tailMatches(IGNORE_CASE, previousWords, "OVERRIDING") {
+		return completeFromList(text, "SYSTEM VALUE", "USER VALUE")
+	}
+
+	/* Complete after OVERRIDING clause */
+	if tailMatches(IGNORE_CASE, previousWords, "OVERRIDING", "*", "VALUE") {
+		return completeFromList(text, "SELECT", "TABLE", "VALUES")
+	}
+
+	/* Insert an open parenthesis after "VALUES" */
+	if tailMatches(IGNORE_CASE, previousWords, "VALUES") && !tailMatches(IGNORE_CASE, previousWords, "DEFAULT", "VALUES") {
+		return completeFromList(text, "(")
+	}
+	/* UPDATE --- can be inside EXPLAIN, RULE, etc */
+	/* If prev. word is UPDATE suggest a list of tables */
+	if tailMatches(IGNORE_CASE, previousWords, "UPDATE") {
+		return c.completeWithUpdatables(text)
+	}
+	/* Complete UPDATE <table> with "SET" */
+	if tailMatches(IGNORE_CASE, previousWords, "UPDATE", "*") {
+		return completeFromList(text, "SET")
+	}
+	/* Complete UPDATE <table> SET with list of attributes */
+	if tailMatches(IGNORE_CASE, previousWords, "UPDATE", "*", "SET") {
+		return c.completeWithAttributes(IGNORE_CASE, previousWords[1], text)
+	}
+	/* UPDATE <table> SET <attr> = */
+	if tailMatches(IGNORE_CASE, previousWords, "UPDATE", "*", "SET", "!*=") {
+		return completeFromList(text, "=")
+	}
+	/* WHERE */
+	/* Simple case of the word before the where being the table name */
+	if tailMatches(IGNORE_CASE, previousWords, "*", "WHERE") {
+		// TODO would be great to _try_ to parse the (incomplete) query
+		// and get a list of possible selectables to filter by
+		return c.completeWithAttributes(IGNORE_CASE, previousWords[1], text,
+			"AND",
+			"OR",
+			"CASE",
+			"WHEN",
+			"THEN",
+			"ELSE",
+			"END",
+		)
+	}
+
+	/* ... FROM | JOIN ... */
+	if tailMatches(IGNORE_CASE, previousWords, "FROM|JOIN") {
+		return c.completeWithSelectables(text)
+	}
+	// is suggesting basic sql commands better than nothing?
+	return completeFromList(text, c.sqlCommands...)
+}
+
+func getPreviousWords(point int, buf []rune) []string {
+	var i int
+
+	/*
+	 * Allocate a slice of strings (rune slices). The worst case is that the line contains only
+	 * non-whitespace WORD_BREAKS characters, making each one a separate word.
+	 * This is usually much more space than we need, but it's cheaper than
+	 * doing a separate malloc() for each word.
+	 */
+	previousWords := make([]string, 0, point*2)
+
+	/*
+	 * First we look for a non-word char before the current point.  (This is
+	 * probably useless, if readline is on the same page as we are about what
+	 * is a word, but if so it's cheap.)
+	 */
+	for i = point - 1; i >= 0; i-- {
+		if strings.ContainsRune(WORD_BREAKS, buf[i]) {
+			break
+		}
+	}
+	point = i
+
+	/*
+	 * Now parse words, working backwards, until we hit start of line.  The
+	 * backwards scan has some interesting but intentional properties
+	 * concerning parenthesis handling.
+	 */
+	for point >= 0 {
+		var start, end int
+		inquotes := false
+		parentheses := 0
+
+		/* now find the first non-space which then constitutes the end */
+		end = -1
+		for i = point; i >= 0; i-- {
+			if !unicode.IsSpace(buf[i]) {
+				end = i
+				break
+			}
+		}
+		/* if no end found, we're done */
+		if end < 0 {
+			break
+		}
+
+		/*
+		 * Otherwise we now look for the start.  The start is either the last
+		 * character before any word-break character going backwards from the
+		 * end, or it's simply character 0.  We also handle open quotes and
+		 * parentheses.
+		 */
+		for start = end; start > 0; start-- {
+			if buf[start] == '"' {
+				inquotes = !inquotes
+			}
+			if inquotes {
+				continue
+			}
+			if buf[start] == ')' {
+				parentheses++
+			} else if buf[start] == '(' {
+				parentheses -= 1
+				if parentheses <= 0 {
+					break
+				}
+			} else if parentheses == 0 && strings.ContainsRune(WORD_BREAKS, buf[start-1]) {
+				break
+			}
+		}
+
+		/* Return the word located at start to end inclusive */
+		i = end - start + 1
+		previousWords = append(previousWords, string(buf[start:start+i]))
+
+		/* Continue searching */
+		point = start - 1
+	}
+
+	return previousWords
+}
+
+func tailMatches(ct caseType, words []string, patterns ...string) bool {
+	if len(words) < len(patterns) {
+		return false
+	}
+	for i, p := range patterns {
+		if !wordMatches(ct, p, words[len(patterns)-i-1]) {
+			return false
+		}
+	}
+	return true
+}
+
+func matches(ct caseType, words []string, patterns ...string) bool {
+	if len(words) != len(patterns) {
+		return false
+	}
+	for i, p := range patterns {
+		if !wordMatches(ct, p, words[len(patterns)-i-1]) {
+			return false
+		}
+	}
+	return true
+}
+
+func wordMatches(ct caseType, pattern, word string) bool {
+	if pattern == "*" {
+		return true
+	}
+
+	if pattern[0] == '!' {
+		return !wordMatches(ct, pattern[1:], word)
+	}
+
+	cmp := func(a, b string) bool { return a == b }
+	if ct == IGNORE_CASE {
+		cmp = strings.EqualFold
+	}
+
+	for _, p := range strings.Split(pattern, "|") {
+		star := strings.IndexByte(p, '*')
+		if star == -1 {
+			return cmp(p, word)
+		} else {
+			return len(word) >= len(p)-1 && cmp(p[0:star], word[0:star]) && (star >= len(p) || cmp(p[star+1:], word[len(word)-len(p)+star+1:]))
+		}
+	}
+
+	return false
+}
+
+func completeFromList(text []rune, options ...string) [][]rune {
+	return completeFromListCase(IGNORE_CASE, text, options...)
+}
+
+func completeFromListCase(ct caseType, text []rune, options ...string) [][]rune {
+	isLower := false
+	if len(text) > 0 {
+		isLower = unicode.IsLower(text[0])
+	}
+	prefix := string(text)
+	if ct == IGNORE_CASE {
+		prefix = strings.ToUpper(prefix)
+	}
+	result := make([][]rune, 0, len(options))
+	for _, o := range options {
+		if (ct == IGNORE_CASE && !strings.HasPrefix(strings.ToUpper(o), prefix)) ||
+			(ct == MATCH_CASE && !strings.HasPrefix(o, prefix)) {
+			continue
+		}
+		match := o[len(text):]
+		if ct == IGNORE_CASE && isLower {
+			match = strings.ToLower(match)
+		}
+		result = append(result, []rune(match))
+	}
+	return result
+}
+
+func completeFromVariables(text []rune, prefix, suffix string, needValue bool) [][]rune {
+	vars := env.All()
+	names := make([]string, 0, len(vars))
+	for name, value := range vars {
+		if needValue && value == "" {
+			continue
+		}
+		names = append(names, fmt.Sprintf("%s%s%s", prefix, name, suffix))
+	}
+	return completeFromListCase(MATCH_CASE, text, names...)
+}
+
+func (c completer) completeWithSelectables(text []rune) [][]rune {
+	filter := parseIdentifier(string(text))
+	names := c.getNamespaces(filter)
+	if r, ok := c.reader.(metadata.TableReader); ok {
+		tables := c.getNames(
+			func() (iterator, error) {
+				return r.Tables(filter)
+			},
+			func(res interface{}) string {
+				t := res.(*metadata.TableSet).Get()
+				return qualifiedIdentifier(filter, t.Catalog, t.Schema, t.Name)
+			},
+		)
+		names = append(names, tables...)
+	}
+	if r, ok := c.reader.(metadata.FunctionReader); ok {
+		functions := c.getNames(
+			func() (iterator, error) {
+				return r.Functions(filter)
+			},
+			func(res interface{}) string {
+				f := res.(*metadata.FunctionSet).Get()
+				return qualifiedIdentifier(filter, f.Catalog, f.Schema, f.Name)
+			},
+		)
+		names = append(names, functions...)
+	}
+	if r, ok := c.reader.(metadata.SequenceReader); ok {
+		sequences := c.getNames(
+			func() (iterator, error) {
+				return r.Sequences(filter)
+			},
+			func(res interface{}) string {
+				s := res.(*metadata.SequenceSet).Get()
+				return qualifiedIdentifier(filter, s.Catalog, s.Schema, s.Name)
+			},
+		)
+		names = append(names, sequences...)
+	}
+	sort.Strings(names)
+	// TODO make sure completeFromList would properly handle quoted identifiers
+	return completeFromList(text, names...)
+}
+
+func (c completer) completeWithUpdatables(text []rune) [][]rune {
+	filter := parseIdentifier(string(text))
+	names := c.getNamespaces(filter)
+	if r, ok := c.reader.(metadata.TableReader); ok {
+		// exclude materialized views, sequences, system tables, synonyms
+		filter.Types = []string{"TABLE", "BASE TABLE", "LOCAL TEMPORARY", "GLOBAL TEMPORARY", "VIEW"}
+		tables := c.getNames(
+			func() (iterator, error) {
+				return r.Tables(filter)
+			},
+			func(res interface{}) string {
+				t := res.(*metadata.TableSet).Get()
+				return qualifiedIdentifier(filter, t.Catalog, t.Schema, t.Name)
+			},
+		)
+		names = append(names, tables...)
+	}
+	sort.Strings(names)
+	// TODO make sure completeFromList would properly handle quoted identifiers
+	return completeFromList(text, names...)
+}
+
+func (c completer) getNamespaces(f metadata.Filter) []string {
+	names := make([]string, 0, 10)
+	if f.Catalog == "" && f.Schema == "" {
+		if r, ok := c.reader.(metadata.CatalogReader); ok {
+			catalogs := c.getNames(
+				func() (iterator, error) { return r.Catalogs(metadata.Filter{}) },
+				func(res interface{}) string {
+					return res.(*metadata.CatalogSet).Get().Catalog
+				},
+			)
+			names = append(names, catalogs...)
+		}
+	}
+	if f.Catalog != "" {
+		// filter is already fully qualified, so don't return any namespaces
+		return names
+	}
+	if r, ok := c.reader.(metadata.SchemaReader); ok {
+		schemas := c.getNames(
+			func() (iterator, error) {
+				if f.Schema != "" {
+					// name should already have a wildcard appended
+					return r.Schemas(metadata.Filter{Catalog: f.Schema, Name: f.Name, WithSystem: true})
+				}
+				return r.Schemas(f)
+			},
+			func(res interface{}) string {
+				s := res.(*metadata.SchemaSet).Get()
+				return qualifiedIdentifier(f, "", s.Catalog, s.Schema)
+			},
+		)
+		names = append(names, schemas...)
+	}
+	return names
+}
+
+func (c completer) completeWithAttributes(ct caseType, selectable string, text []rune, options ...string) [][]rune {
+	names := make([]string, 0, 10)
+	if r, ok := c.reader.(metadata.ColumnReader); ok {
+		parent := parseParentIdentifier(selectable)
+		columns := c.getNames(
+			func() (iterator, error) {
+				return r.Columns(parent)
+			},
+			func(res interface{}) string {
+				return res.(*metadata.ColumnSet).Get().Name
+			},
+		)
+		names = append(names, columns...)
+	}
+	if r, ok := c.reader.(metadata.FunctionReader); ok {
+		filter := parseIdentifier(string(text))
+		// functions don't have to be fully qualified to be callable
+		filter.OnlyVisible = false
+		functions := c.getNames(
+			func() (iterator, error) {
+				return r.Functions(filter)
+			},
+			func(res interface{}) string {
+				return res.(*metadata.FunctionSet).Get().Name
+			},
+		)
+		names = append(names, functions...)
+	}
+	names = append(names, options...)
+	return completeFromList(text, names...)
+}
+
+// parseIdentifier into catalog, schema and name
+func parseIdentifier(name string) metadata.Filter {
+	// TODO handle quoted identifiers
+	result := metadata.Filter{}
+	if !strings.ContainsRune(name, '.') {
+		result.Name = name + "%"
+		result.OnlyVisible = true
+	} else {
+		parts := strings.SplitN(name, ".", 3)
+		if len(parts) == 2 {
+			result.Schema = parts[0]
+			result.Name = parts[1] + "%"
+		} else {
+			result.Catalog = parts[0]
+			result.Schema = parts[1]
+			result.Name = parts[2] + "%"
+		}
+	}
+
+	if result.Schema != "" || len(result.Name) > 3 {
+		result.WithSystem = true
+	}
+	return result
+}
+
+// parseParentIdentifier into catalog, schema and parent
+func parseParentIdentifier(name string) metadata.Filter {
+	// TODO handle quoted identifiers
+	result := metadata.Filter{}
+	if !strings.ContainsRune(name, '.') {
+		result.Parent = name
+		result.OnlyVisible = true
+	} else {
+		parts := strings.SplitN(name, ".", 3)
+		if len(parts) == 2 {
+			result.Schema = parts[0]
+			result.Parent = parts[1]
+		} else {
+			result.Catalog = parts[0]
+			result.Schema = parts[1]
+			result.Parent = parts[2]
+		}
+	}
+
+	if result.Schema != "" {
+		result.WithSystem = true
+	}
+	return result
+}
+
+func qualifiedIdentifier(filter metadata.Filter, catalog, schema, name string) string {
+	// TODO handle quoted identifiers
+	if filter.Catalog != "" && filter.Schema != "" {
+		return catalog + "." + schema + "." + name
+	}
+	if filter.Schema != "" {
+		return schema + "." + name
+	}
+	return name
+}
+
+func (c completer) getNames(query func() (iterator, error), mapper func(interface{}) string) []string {
+	res, err := query()
+	if err != nil {
+		if err != metadata.ErrNotSupported {
+			c.logger.Println("Error getting selectables", err)
+		}
+		return nil
+	}
+	defer res.Close()
+
+	// there can be duplicates if names are not qualified
+	values := make(map[string]struct{}, 10)
+	for res.Next() {
+		values[mapper(res)] = struct{}{}
+	}
+	result := make([]string, 0, len(values))
+	for v := range values {
+		result = append(result, v)
+	}
+	return result
+}
+
+type iterator interface {
+	Next() bool
+	Close() error
+}

--- a/drivers/completer/completer_test.go
+++ b/drivers/completer/completer_test.go
@@ -1,0 +1,309 @@
+package completer
+
+import (
+	"testing"
+
+	"github.com/xo/usql/drivers/metadata"
+)
+
+func TestCompleter(t *testing.T) {
+	cases := []struct {
+		name           string
+		line           string
+		start          int
+		expSuggestions []string
+		expLength      int
+	}{
+		{
+			"Single SQL keyword, uppercase",
+			"SEL",
+			3,
+			[]string{
+				"ECT",
+			},
+			3,
+		},
+		{
+			"Single SQL keyword, lowercase",
+			"ex",
+			2,
+			[]string{
+				"ec",
+				"ecute",
+				"plain",
+			},
+			2,
+		},
+		{
+			"usql command",
+			`\dt`,
+			3,
+			[]string{
+				`+`,
+				``,
+				`S+`,
+				`S`,
+			},
+			3,
+		},
+		{
+			"3rd word",
+			"SELECT * F",
+			10,
+			[]string{
+				"ULL OUTER JOIN",
+				"ROM",
+				"ETCH",
+			},
+			1,
+		},
+		{
+			"Selectables",
+			"SELECT * FROM ",
+			14,
+			[]string{
+				"main",
+				"remote",
+				"default",
+				"system",
+				"film",
+				"factory",
+			},
+			0,
+		},
+		{
+			"Namespaced with catalog",
+			"SELECT * FROM remote.",
+			21,
+			[]string{
+				"film",
+				"factory",
+			},
+			7,
+		},
+		{
+			"Namespaced with schema",
+			"SELECT * FROM system.",
+			21,
+			[]string{
+				"film",
+				"factory",
+			},
+			7,
+		},
+		{
+			"Namespaced with catalog.schema",
+			"SELECT * FROM remote.default.f",
+			30,
+			[]string{
+				"ilm",
+				"actory",
+			},
+			16,
+		},
+		{
+			"Attributes",
+			"SELECT * FROM film WHERE ",
+			25,
+			[]string{
+				"id",
+				"name",
+				"CASE",
+				"AND",
+				"OR",
+				"WHEN",
+				"THEN",
+				"ELSE",
+				"END",
+			},
+			0,
+		},
+		{
+			"insert",
+			"INS",
+			3,
+			[]string{
+				"ERT",
+			},
+			3,
+		},
+		{
+			"insert into",
+			"INSERT IN",
+			9,
+			[]string{
+				"TO",
+			},
+			2,
+		},
+		{
+			"insert into table",
+			"INSERT INTO fi",
+			14,
+			[]string{
+				"lm",
+			},
+			2,
+		},
+		{
+			"insert into table select from",
+			"INSERT INTO film SE",
+			19,
+			[]string{
+				"LECT",
+			},
+			2,
+		},
+		{
+			"insert into table attrs",
+			"INSERT INTO film (",
+			18,
+			[]string{
+				"id",
+				"name",
+			},
+			0,
+		},
+		{
+			"insert into table values",
+			"INSERT INTO film (a)",
+			20,
+			[]string{
+				"SELECT",
+				"TABLE",
+				"VALUES",
+				"OVERRIDING",
+			},
+			0,
+		},
+		{
+			"update table set attrs",
+			"UPDATE film SET ",
+			16,
+			[]string{
+				"id",
+				"name",
+			},
+			0,
+		},
+		{
+			"update table set",
+			"update film set name ",
+			21,
+			[]string{
+				"=",
+			},
+			0,
+		},
+		{
+			"variables",
+			":a",
+			2,
+			[]string{},
+			2,
+		},
+	}
+
+	completer := NewDefaultCompleter(mockReader{})(nil)
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			suggestions, length := completer.Do([]rune(test.line), test.start)
+			// need at least 2 pairs of nested loops, one for what's missing, second for what's extra
+			for _, exp := range test.expSuggestions {
+				found := false
+				for _, act := range suggestions {
+					if string(act) == exp {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Missing expected suggestion: %s", exp)
+				}
+			}
+			for _, act := range suggestions {
+				found := false
+				for _, exp := range test.expSuggestions {
+					if string(act) == exp {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Unexpected suggestion: %s", string(act))
+				}
+			}
+			if length != test.expLength {
+				t.Errorf("Expected Do() to return length %d, got %d", test.expLength, length)
+			}
+		})
+	}
+}
+
+type mockReader struct{}
+
+var _ metadata.CatalogReader = &mockReader{}
+var _ metadata.BasicReader = &mockReader{}
+
+func (r mockReader) Catalogs(metadata.Filter) (*metadata.CatalogSet, error) {
+	return metadata.NewCatalogSet([]metadata.Catalog{
+		{
+			Catalog: "main",
+		},
+		{
+			Catalog: "remote",
+		},
+	}), nil
+}
+
+func (r mockReader) Schemas(metadata.Filter) (*metadata.SchemaSet, error) {
+	return metadata.NewSchemaSet([]metadata.Schema{
+		{
+			Schema:  "default",
+			Catalog: "main",
+		},
+		{
+			Schema:  "system",
+			Catalog: "main",
+		},
+	}), nil
+}
+
+func (r mockReader) Tables(f metadata.Filter) (*metadata.TableSet, error) {
+	return metadata.NewTableSet([]metadata.Table{
+		{
+			Catalog: f.Catalog,
+			Schema:  f.Schema,
+			Name:    "film",
+		},
+		{
+			Catalog: f.Catalog,
+			Schema:  f.Schema,
+			Name:    "factory",
+		},
+	}), nil
+}
+
+func (r mockReader) Columns(f metadata.Filter) (*metadata.ColumnSet, error) {
+	if f.Parent == "film" {
+		return metadata.NewColumnSet([]metadata.Column{
+			{
+				Name: "id",
+			},
+			{
+				Name: "name",
+			},
+		}), nil
+	}
+	return metadata.NewColumnSet([]metadata.Column{
+		{
+			Name: f.Catalog,
+		},
+		{
+			Name: f.Schema,
+		},
+		{
+			Name: f.Name,
+		},
+	}), nil
+}

--- a/drivers/sqlite3/reader_test.go
+++ b/drivers/sqlite3/reader_test.go
@@ -168,7 +168,7 @@ func TestColumns(t *testing.T) {
 		names = append(names, result.Get().Name)
 	}
 	actual := strings.Join(names, ", ")
-	expected := "film_id, title, description, release_year, language_id, original_language_id, rental_duration, rental_rate, length, replacement_cost, rating, special_features, last_update, actor_id, film_id, last_update, film_id, category_id, last_update, film_id, title, description, FID, title, description, category, price, length, rating, actors"
+	expected := "description, film_id, language_id, last_update, length, original_language_id, rating, release_year, rental_duration, rental_rate, replacement_cost, special_features, title, actor_id, film_id, last_update, category_id, film_id, last_update, description, film_id, title, FID, actors, category, description, length, price, rating, title"
 	if actual != expected {
 		t.Errorf("Wrong column names, expected:\n  %v, got:\n  %v", expected, names)
 	}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -544,6 +544,7 @@ func (h *Handler) Open(params ...string) error {
 	// force error/check connection
 	if err == nil {
 		if err = drivers.Ping(h.u, h.db); err == nil {
+			h.l.Completer(drivers.NewCompleter(h.u, h.db))
 			return h.Version()
 		}
 	}


### PR DESCRIPTION
Add a pretty basic, generic context-based autocomplete, inspired heavily by psql's [tab-complete.c](https://github.com/postgres/postgres/blob/master/src/bin/psql/tab-complete.c). Currently, only a small subset of completions from psql are implemented, since most will be PostgreSQL specific. This first iteration is focused on SELECT, INSERT, UPDATE, DELETE.

There's a new interface allowing drivers to provide their own completer and the default one should be a fallback. If it won't work well for some drivers, due to the reader not being able to read the catalog quickly enough (👀 Oracle), an empty struct can be passed as a reader, falling back to completing only SQL keywords. I don't think we need a way to disable it completely.

The completer will execute multiple database queries against system catalogs. There's no caching, on purpose.

I've NOT tested it with Oracle, only PostgreSQL, SQLServer, and SQLite. There are basic unit tests.

~This PR includes the commit from #188, so either individual commits should be reviewed, or #188 needs to be merged first.~

Closes #150  and closes #110. Doesn't yet solve #41, which asks for autocomplete of files after `\i`, but it would be trivial to add after this.

If this gets merged, I'll create issues for the next steps that include:
* make the completer extendable to easily configure SQL keywords supported by particular databases, start with SQLite, MySQL, MSSQL
* complete arguments for backslash commands, including listing local files for #41
* ~add more contexts for DML commands like INSERT, UPDATE, DELETE~
* add more contexts for DDL commands like CREATE, ALTER