### PR TITLE
Add filters to metadata readers

### DIFF
--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -3,6 +3,7 @@
 package drivers
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -21,9 +22,13 @@ import (
 // database/sql.DB and database/sql.Tx.
 type DB interface {
 	Exec(string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 	Query(string, ...interface{}) (*sql.Rows, error)
+	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
 	QueryRow(string, ...interface{}) *sql.Row
+	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 	Prepare(string) (*sql.Stmt, error)
+	PrepareContext(context.Context, string) (*sql.Stmt, error)
 }
 
 // Driver holds funcs for a driver.

--- a/drivers/godror/godror.go
+++ b/drivers/godror/godror.go
@@ -110,10 +110,7 @@ func init() {
 		},
 		NewMetadataReader: orameta.NewReader(),
 		NewMetadataWriter: func(db drivers.DB, w io.Writer, opts ...metadata.ReaderOption) metadata.Writer {
-			writerOpts := []metadata.WriterOption{
-				metadata.WithSystemSchemas([]string{"ctxsys", "flows_files", "mdsys", "outln", "sys", "system", "xdb", "xs$null"}),
-			}
-			return metadata.NewDefaultWriter(orameta.NewReader()(db, opts...), writerOpts...)(db, w)
+			return metadata.NewDefaultWriter(orameta.NewReader()(db, opts...))(db, w)
 		},
 	})
 }

--- a/drivers/metadata/informationschema/metadata_test.go
+++ b/drivers/metadata/informationschema/metadata_test.go
@@ -106,6 +106,7 @@ var (
 			URL:        "sqlserver://sa:" + url.QueryEscape(pw) + "@127.0.0.1:%s?database=sakila",
 			DockerPort: "1433/tcp",
 			Opts: []metadata.ReaderOption{
+				infos.WithPlaceholder(func(n int) string { return fmt.Sprintf("@p%d", n) }),
 				infos.WithIndexes(false),
 				infos.WithCustomColumns(map[infos.ColumnName]string{
 					infos.FunctionsSecurityType: "''",

--- a/drivers/metadata/informationschema/metadata_test.go
+++ b/drivers/metadata/informationschema/metadata_test.go
@@ -228,7 +228,7 @@ func TestSchemas(t *testing.T) {
 	for dbName, db := range dbs {
 		r := db.Reader
 
-		result, err := r.Schemas("", "")
+		result, err := r.Schemas(metadata.Filter{})
 		if err != nil {
 			log.Fatalf("Could not read %s schemas: %v", dbName, err)
 		}
@@ -260,7 +260,7 @@ func TestTables(t *testing.T) {
 	for dbName, db := range dbs {
 		r := db.Reader
 
-		result, err := r.Tables("", schemas[dbName], "", []string{"BASE TABLE", "TABLE", "VIEW"})
+		result, err := r.Tables(metadata.Filter{Schema: schemas[dbName], Types: []string{"BASE TABLE", "TABLE", "VIEW"}})
 		if err != nil {
 			log.Fatalf("Could not read %s tables: %v", dbName, err)
 		}
@@ -298,7 +298,7 @@ func TestColumns(t *testing.T) {
 	for dbName, db := range dbs {
 		r := db.Reader
 
-		result, err := r.Columns("", schemas[dbName], tables[dbName])
+		result, err := r.Columns(metadata.Filter{Schema: schemas[dbName], Parent: tables[dbName]})
 		if err != nil {
 			log.Fatalf("Could not read %s columns: %v", dbName, err)
 		}
@@ -329,7 +329,7 @@ func TestFunctions(t *testing.T) {
 		}
 		r := infos.New(db.Opts...)(db.DB).(metadata.FunctionReader)
 
-		result, err := r.Functions("", schemas[dbName], "", []string{})
+		result, err := r.Functions(metadata.Filter{Schema: schemas[dbName]})
 		if err != nil {
 			log.Fatalf("Could not read %s functions: %v", dbName, err)
 		}
@@ -364,7 +364,7 @@ func TestFunctionColumns(t *testing.T) {
 		}
 		r := infos.New(db.Opts...)(db.DB).(metadata.FunctionColumnReader)
 
-		result, err := r.FunctionColumns("", schemas[dbName], tables[dbName])
+		result, err := r.FunctionColumns(metadata.Filter{Schema: schemas[dbName], Parent: tables[dbName]})
 		if err != nil {
 			log.Fatalf("Could not read %s function columns: %v", dbName, err)
 		}
@@ -393,7 +393,7 @@ func TestIndexes(t *testing.T) {
 		}
 		r := infos.New(db.Opts...)(db.DB).(metadata.IndexReader)
 
-		result, err := r.Indexes("", schemas[dbName], "", "")
+		result, err := r.Indexes(metadata.Filter{Schema: schemas[dbName]})
 		if err != nil {
 			log.Fatalf("Could not read %s indexes: %v", dbName, err)
 		}
@@ -425,7 +425,7 @@ func TestIndexColumns(t *testing.T) {
 		}
 		r := infos.New(db.Opts...)(db.DB).(metadata.IndexColumnReader)
 
-		result, err := r.IndexColumns("", schemas[dbName], "", tables[dbName])
+		result, err := r.IndexColumns(metadata.Filter{Schema: schemas[dbName], Name: tables[dbName]})
 		if err != nil {
 			log.Fatalf("Could not read %s index columns: %v", dbName, err)
 		}
@@ -454,7 +454,7 @@ func TestSequences(t *testing.T) {
 		}
 		r := infos.New(db.Opts...)(db.DB).(metadata.SequenceReader)
 
-		result, err := r.Sequences("", schemas[dbName], "")
+		result, err := r.Sequences(metadata.Filter{Schema: schemas[dbName]})
 		if err != nil {
 			log.Fatalf("Could not read %s sequences: %v", dbName, err)
 		}

--- a/drivers/metadata/informationschema/metadata_test.go
+++ b/drivers/metadata/informationschema/metadata_test.go
@@ -63,6 +63,7 @@ var (
 					infos.ColumnsColumnSize:         "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
 					infos.FunctionColumnsColumnSize: "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
 				}),
+				infos.WithSystemSchemas([]string{"pg_catalog", "pg_toast", "information_schema"}),
 			},
 		},
 		"mysql": {
@@ -86,6 +87,7 @@ var (
 					infos.ColumnsNumericPrecRadix:         "10",
 					infos.FunctionColumnsNumericPrecRadix: "10",
 				}),
+				infos.WithSystemSchemas([]string{"mysql", "performance_schema", "information_schema"}),
 			},
 		},
 		"sqlserver": {
@@ -107,6 +109,19 @@ var (
 				infos.WithIndexes(false),
 				infos.WithCustomColumns(map[infos.ColumnName]string{
 					infos.FunctionsSecurityType: "''",
+				}),
+				infos.WithSystemSchemas([]string{
+					"db_accessadmin",
+					"db_backupoperator",
+					"db_datareader",
+					"db_datawriter",
+					"db_ddladmin",
+					"db_denydatareader",
+					"db_denydatawriter",
+					"db_owner",
+					"db_securityadmin",
+					"INFORMATION_SCHEMA",
+					"sys",
 				}),
 			},
 		},
@@ -228,7 +243,7 @@ func TestSchemas(t *testing.T) {
 	for dbName, db := range dbs {
 		r := db.Reader
 
-		result, err := r.Schemas(metadata.Filter{})
+		result, err := r.Schemas(metadata.Filter{WithSystem: true})
 		if err != nil {
 			log.Fatalf("Could not read %s schemas: %v", dbName, err)
 		}

--- a/drivers/metadata/metadata.go
+++ b/drivers/metadata/metadata.go
@@ -32,59 +32,80 @@ type BasicReader interface {
 // CatalogReader lists database schemas.
 type CatalogReader interface {
 	Reader
-	Catalogs() (*CatalogSet, error)
+	Catalogs(Filter) (*CatalogSet, error)
 }
 
 // SchemaReader lists database schemas.
 type SchemaReader interface {
 	Reader
-	Schemas(catalog, schemaPattern string) (*SchemaSet, error)
+	Schemas(Filter) (*SchemaSet, error)
 }
 
 // TableReader lists database tables.
 type TableReader interface {
 	Reader
-	Tables(catalog, schemaPattern, namePattern string, types []string) (*TableSet, error)
+	Tables(Filter) (*TableSet, error)
 }
 
 // ColumnReader lists table columns.
 type ColumnReader interface {
 	Reader
-	Columns(catalog, schemaPattern, tablePattern string) (*ColumnSet, error)
+	Columns(Filter) (*ColumnSet, error)
 }
 
 // IndexReader lists database indexes.
 type IndexReader interface {
 	Reader
-	Indexes(catalog, schemaPattern, tablePattern, namePattern string) (*IndexSet, error)
+	Indexes(Filter) (*IndexSet, error)
 }
 
 // IndexColumnReader lists database indexes.
 type IndexColumnReader interface {
 	Reader
-	IndexColumns(catalog, schemaPattern, tablePattern, indexPattern string) (*IndexColumnSet, error)
+	IndexColumns(Filter) (*IndexColumnSet, error)
 }
 
 // FunctionReader lists database functions.
 type FunctionReader interface {
 	Reader
-	Functions(catalog, schemaPattern, namePattern string, types []string) (*FunctionSet, error)
+	Functions(Filter) (*FunctionSet, error)
 }
 
 // FunctionColumnReader lists function parameters.
 type FunctionColumnReader interface {
 	Reader
-	FunctionColumns(catalog, schemaPattern, functionPattern string) (*FunctionColumnSet, error)
+	FunctionColumns(Filter) (*FunctionColumnSet, error)
 }
 
 // SequenceReader lists sequences.
 type SequenceReader interface {
 	Reader
-	Sequences(catalog, schemaPattern, namePattern string) (*SequenceSet, error)
+	Sequences(Filter) (*SequenceSet, error)
 }
 
 // Reader of any database metadata in a structured format.
 type Reader interface{}
+
+// Filter objects returned by Readers
+type Filter struct {
+	// Catalog name pattern that objects must belong to;
+	// use Name to filter catalogs by name
+	Catalog string
+	// Schema name pattern that objects must belong to;
+	// use Name to filter schemas by name
+	Schema string
+	// Parent name pattern that objects must belong to;
+	// does not apply to schema and catalog containing matching objects
+	Parent string
+	// Name pattern that object name must match
+	Name string
+	// Types of the object
+	Types []string
+	// WithSystem objects
+	WithSystem bool
+	// WithNotVisible objects
+	WithNotVisible bool
+}
 
 // Writer of database metadata in a human readable format.
 type Writer interface {

--- a/drivers/metadata/metadata.go
+++ b/drivers/metadata/metadata.go
@@ -103,8 +103,8 @@ type Filter struct {
 	Types []string
 	// WithSystem objects
 	WithSystem bool
-	// WithNotVisible objects
-	WithNotVisible bool
+	// OnlyVisible objects
+	OnlyVisible bool
 }
 
 // Writer of database metadata in a human readable format.

--- a/drivers/metadata/metadata_test.go
+++ b/drivers/metadata/metadata_test.go
@@ -58,6 +58,7 @@ var (
 					infos.ColumnsColumnSize:         "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
 					infos.FunctionColumnsColumnSize: "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
 				}),
+				infos.WithSystemSchemas([]string{"pg_catalog", "pg_toast", "information_schema"}),
 			},
 			WriterOpts: []metadata.WriterOption{
 				metadata.WithSystemSchemas([]string{"pg_catalog", "pg_toast", "information_schema"}),
@@ -85,9 +86,7 @@ var (
 					infos.ColumnsNumericPrecRadix:         "10",
 					infos.FunctionColumnsNumericPrecRadix: "10",
 				}),
-			},
-			WriterOpts: []metadata.WriterOption{
-				metadata.WithSystemSchemas([]string{"mysql", "performance_schema", "information_schema"}),
+				infos.WithSystemSchemas([]string{"mysql", "performance_schema", "information_schema"}),
 			},
 		},
 		"trino": {

--- a/drivers/metadata/oracle/metadata.go
+++ b/drivers/metadata/oracle/metadata.go
@@ -447,6 +447,9 @@ func (r metaReader) conditions(filter metadata.Filter, formats formats) ([]strin
 	if !filter.WithSystem && formats.notSchemas != "" {
 		conds = append(conds, fmt.Sprintf(formats.notSchemas, r.systemSchemas))
 	}
+	if filter.OnlyVisible && formats.schema != "" {
+		conds = append(conds, fmt.Sprintf(formats.schema, "user"))
+	}
 	if filter.Parent != "" && formats.parent != "" {
 		vals = append(vals, filter.Parent)
 		conds = append(conds, fmt.Sprintf(formats.parent, baseParam))

--- a/drivers/metadata/oracle/metadata.go
+++ b/drivers/metadata/oracle/metadata.go
@@ -23,7 +23,7 @@ func NewReader() func(drivers.DB, ...metadata.ReaderOption) metadata.Reader {
 	return func(db drivers.DB, opts ...metadata.ReaderOption) metadata.Reader {
 		r := &metaReader{
 			LoggingReader: metadata.NewLoggingReader(db, opts...),
-			systemSchemas: "'ctxsys', 'flows_files', 'mdsys', 'outln', 'sys', 'system', 'xdb', 'xs$null'",
+			systemSchemas: "'CTXSYS', 'FLOWS_FILES', 'MDSYS', 'OUTLN', 'SYS', 'SYSTEM', 'XDB', 'XS$NULL'",
 		}
 		return r
 	}

--- a/drivers/metadata/reader.go
+++ b/drivers/metadata/reader.go
@@ -8,15 +8,15 @@ import (
 
 // PluginReader allows to be easily composed from other readers
 type PluginReader struct {
-	catalogs        func() (*CatalogSet, error)
-	schemas         func(catalog, schemaPattern string) (*SchemaSet, error)
-	tables          func(catalog, schemaPattern, namePattern string, types []string) (*TableSet, error)
-	columns         func(catalog, schemaPattern, tablePattern string) (*ColumnSet, error)
-	indexes         func(catalog, schemaPattern, tablePattern, namePattern string) (*IndexSet, error)
-	indexColumns    func(catalog, schemaPattern, tablePattern, indexPattern string) (*IndexColumnSet, error)
-	functions       func(catalog, schemaPattern, namePattern string, types []string) (*FunctionSet, error)
-	functionColumns func(catalog, schemaPattern, functionPattern string) (*FunctionColumnSet, error)
-	sequences       func(catalog, schemaPattern, namePattern string) (*SequenceSet, error)
+	catalogs        func(Filter) (*CatalogSet, error)
+	schemas         func(Filter) (*SchemaSet, error)
+	tables          func(Filter) (*TableSet, error)
+	columns         func(Filter) (*ColumnSet, error)
+	indexes         func(Filter) (*IndexSet, error)
+	indexColumns    func(Filter) (*IndexColumnSet, error)
+	functions       func(Filter) (*FunctionSet, error)
+	functionColumns func(Filter) (*FunctionColumnSet, error)
+	sequences       func(Filter) (*SequenceSet, error)
 }
 
 var _ ExtendedReader = &PluginReader{}
@@ -56,67 +56,67 @@ func NewPluginReader(readers ...Reader) Reader {
 	return &p
 }
 
-func (p PluginReader) Catalogs() (*CatalogSet, error) {
+func (p PluginReader) Catalogs(f Filter) (*CatalogSet, error) {
 	if p.catalogs == nil {
 		return nil, ErrNotSupported
 	}
-	return p.catalogs()
+	return p.catalogs(f)
 }
 
-func (p PluginReader) Schemas(catalog, schemaPattern string) (*SchemaSet, error) {
+func (p PluginReader) Schemas(f Filter) (*SchemaSet, error) {
 	if p.schemas == nil {
 		return nil, ErrNotSupported
 	}
-	return p.schemas(catalog, schemaPattern)
+	return p.schemas(f)
 }
 
-func (p PluginReader) Tables(catalog, schemaPattern, namePattern string, types []string) (*TableSet, error) {
+func (p PluginReader) Tables(f Filter) (*TableSet, error) {
 	if p.tables == nil {
 		return nil, ErrNotSupported
 	}
-	return p.tables(catalog, schemaPattern, namePattern, types)
+	return p.tables(f)
 }
 
-func (p PluginReader) Columns(catalog, schemaPattern, tablePattern string) (*ColumnSet, error) {
+func (p PluginReader) Columns(f Filter) (*ColumnSet, error) {
 	if p.columns == nil {
 		return nil, ErrNotSupported
 	}
-	return p.columns(catalog, schemaPattern, tablePattern)
+	return p.columns(f)
 }
 
-func (p PluginReader) Indexes(catalog, schemaPattern, tablePattern, namePattern string) (*IndexSet, error) {
+func (p PluginReader) Indexes(f Filter) (*IndexSet, error) {
 	if p.indexes == nil {
 		return nil, ErrNotSupported
 	}
-	return p.indexes(catalog, schemaPattern, tablePattern, namePattern)
+	return p.indexes(f)
 }
 
-func (p PluginReader) IndexColumns(catalog, schemaPattern, tablePattern, indexPattern string) (*IndexColumnSet, error) {
+func (p PluginReader) IndexColumns(f Filter) (*IndexColumnSet, error) {
 	if p.indexColumns == nil {
 		return nil, ErrNotSupported
 	}
-	return p.indexColumns(catalog, schemaPattern, tablePattern, indexPattern)
+	return p.indexColumns(f)
 }
 
-func (p PluginReader) Functions(catalog, schemaPattern, namePattern string, types []string) (*FunctionSet, error) {
+func (p PluginReader) Functions(f Filter) (*FunctionSet, error) {
 	if p.functions == nil {
 		return nil, ErrNotSupported
 	}
-	return p.functions(catalog, schemaPattern, namePattern, types)
+	return p.functions(f)
 }
 
-func (p PluginReader) FunctionColumns(catalog, schemaPattern, functionPattern string) (*FunctionColumnSet, error) {
+func (p PluginReader) FunctionColumns(f Filter) (*FunctionColumnSet, error) {
 	if p.functionColumns == nil {
 		return nil, ErrNotSupported
 	}
-	return p.functionColumns(catalog, schemaPattern, functionPattern)
+	return p.functionColumns(f)
 }
 
-func (p PluginReader) Sequences(catalog, schemaPattern, namePattern string) (*SequenceSet, error) {
+func (p PluginReader) Sequences(f Filter) (*SequenceSet, error) {
 	if p.sequences == nil {
 		return nil, ErrNotSupported
 	}
-	return p.sequences(catalog, schemaPattern, namePattern)
+	return p.sequences(f)
 }
 
 type LoggingReader struct {

--- a/drivers/metadata/reader.go
+++ b/drivers/metadata/reader.go
@@ -192,10 +192,6 @@ func (r *LoggingReader) setDryRun(d bool) {
 }
 
 func (r *LoggingReader) setTimeout(t time.Duration) {
-	_, ok := r.db.(DBContext)
-	if !ok {
-		panic("trying to set timeout for a logging reader with a non-contextual db")
-	}
 	r.timeout = t
 }
 
@@ -209,7 +205,7 @@ func (r LoggingReader) Query(q string, v ...interface{}) (*sql.Rows, CloseFunc, 
 	}
 	if r.timeout != 0 {
 		ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
-		rows, err := r.db.(DBContext).QueryContext(ctx, q, v...)
+		rows, err := r.db.QueryContext(ctx, q, v...)
 		return rows, func() { cancel(); rows.Close() }, err
 	}
 	rows, err := r.db.Query(q, v...)

--- a/drivers/metadata/writer.go
+++ b/drivers/metadata/writer.go
@@ -16,16 +16,12 @@ import (
 // database/sql.DB and database/sql.Tx.
 type DB interface {
 	Exec(string, ...interface{}) (sql.Result, error)
-	Query(string, ...interface{}) (*sql.Rows, error)
-	QueryRow(string, ...interface{}) *sql.Row
-	Prepare(string) (*sql.Stmt, error)
-}
-
-type DBContext interface {
-	DB
 	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	Query(string, ...interface{}) (*sql.Rows, error)
 	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
+	QueryRow(string, ...interface{}) *sql.Row
 	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	Prepare(string) (*sql.Stmt, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
 }
 

--- a/drivers/metadata/writer.go
+++ b/drivers/metadata/writer.go
@@ -110,7 +110,7 @@ func (w DefaultWriter) DescribeFunctions(funcTypes, pattern string, verbose, sho
 	if err != nil {
 		return err
 	}
-	res, err := r.Functions("", sp, tp, types)
+	res, err := r.Functions(Filter{Schema: sp, Name: tp, Types: types})
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func (w DefaultWriter) DescribeFunctions(funcTypes, pattern string, verbose, sho
 
 func (w DefaultWriter) getFunctionColumns(c, s, f string) (string, error) {
 	r := w.r.(FunctionColumnReader)
-	cols, err := r.FunctionColumns(c, s, f)
+	cols, err := r.FunctionColumns(Filter{Catalog: c, Schema: s, Parent: f})
 	if err != nil {
 		return "", err
 	}
@@ -190,7 +190,7 @@ func (w DefaultWriter) DescribeTableDetails(pattern string, verbose, showSystem 
 	tr, isTR := w.r.(TableReader)
 	_, isCR := w.r.(ColumnReader)
 	if isTR && isCR {
-		res, err := tr.Tables("", sp, tp, []string{})
+		res, err := tr.Tables(Filter{Schema: sp, Name: tp})
 		if err != nil {
 			return err
 		}
@@ -222,7 +222,7 @@ func (w DefaultWriter) DescribeTableDetails(pattern string, verbose, showSystem 
 	ir, isIR := w.r.(IndexReader)
 	_, isICR := w.r.(IndexColumnReader)
 	if isIR && isICR {
-		res, err := ir.Indexes("", sp, "", tp)
+		res, err := ir.Indexes(Filter{Schema: sp, Name: tp})
 		if err != nil && err != ErrNotSupported {
 			return err
 		}
@@ -254,7 +254,7 @@ func (w DefaultWriter) DescribeTableDetails(pattern string, verbose, showSystem 
 
 func (w DefaultWriter) describeTableDetails(typ, sp, tp string, verbose, showSystem bool) error {
 	r := w.r.(ColumnReader)
-	res, err := r.Columns("", sp, tp)
+	res, err := r.Columns(Filter{Schema: sp, Parent: tp})
 	if err != nil {
 		return err
 	}
@@ -298,7 +298,7 @@ func (w DefaultWriter) describeTableIndexes(sp, tp string) error {
 	if !ok {
 		return nil
 	}
-	res, err := r.Indexes("", sp, tp, "")
+	res, err := r.Indexes(Filter{Schema: sp, Parent: tp})
 	if err != nil && err != ErrNotSupported {
 		return err
 	}
@@ -333,7 +333,7 @@ func (w DefaultWriter) describeTableIndexes(sp, tp string) error {
 
 func (w DefaultWriter) getIndexColumns(c, s, t, i string) (string, error) {
 	r := w.r.(IndexColumnReader)
-	cols, err := r.IndexColumns(c, s, t, i)
+	cols, err := r.IndexColumns(Filter{Catalog: c, Schema: s, Parent: t, Name: i})
 	if err != nil {
 		return "", err
 	}
@@ -346,7 +346,7 @@ func (w DefaultWriter) getIndexColumns(c, s, t, i string) (string, error) {
 
 func (w DefaultWriter) describeSequences(sp, tp string, verbose, showSystem bool) (int, error) {
 	r := w.r.(SequenceReader)
-	res, err := r.Sequences("", sp, tp)
+	res, err := r.Sequences(Filter{Schema: sp, Name: tp})
 	if err != nil && err != ErrNotSupported {
 		return 0, err
 	}
@@ -376,7 +376,7 @@ func (w DefaultWriter) describeSequences(sp, tp string, verbose, showSystem bool
 
 func (w DefaultWriter) describeIndexes(sp, tp, ip string) error {
 	r := w.r.(IndexColumnReader)
-	res, err := r.IndexColumns("", sp, tp, ip)
+	res, err := r.IndexColumns(Filter{Schema: sp, Parent: tp, Name: ip})
 	if err != nil {
 		return err
 	}
@@ -415,7 +415,7 @@ func (w DefaultWriter) ListAllDbs(pattern string, verbose bool) error {
 	if !ok {
 		return fmt.Errorf(text.NotSupportedByDriver, `\l`)
 	}
-	res, err := r.Catalogs()
+	res, err := r.Catalogs(Filter{Name: pattern})
 	if err != nil {
 		return err
 	}
@@ -442,7 +442,7 @@ func (w DefaultWriter) ListTables(tableTypes, pattern string, verbose, showSyste
 	if err != nil {
 		return err
 	}
-	res, err := r.Tables("", sp, tp, types)
+	res, err := r.Tables(Filter{Schema: sp, Name: tp, Types: types})
 	if err != nil {
 		return err
 	}
@@ -483,7 +483,7 @@ func (w DefaultWriter) ListSchemas(pattern string, verbose, showSystem bool) err
 	if !ok {
 		return fmt.Errorf(text.NotSupportedByDriver, `\d`)
 	}
-	res, err := r.Schemas("", pattern)
+	res, err := r.Schemas(Filter{Name: pattern})
 	if err != nil {
 		return err
 	}
@@ -510,7 +510,7 @@ func (w DefaultWriter) ListIndexes(pattern string, verbose, showSystem bool) err
 	if err != nil {
 		return err
 	}
-	res, err := r.Indexes("", sp, "", tp)
+	res, err := r.Indexes(Filter{Schema: sp, Name: tp})
 	if err != nil {
 		return err
 	}

--- a/drivers/metadata/writer.go
+++ b/drivers/metadata/writer.go
@@ -110,13 +110,14 @@ func (w DefaultWriter) DescribeFunctions(funcTypes, pattern string, verbose, sho
 	if err != nil {
 		return err
 	}
-	res, err := r.Functions(Filter{Schema: sp, Name: tp, Types: types})
+	res, err := r.Functions(Filter{Schema: sp, Name: tp, Types: types, WithSystem: showSystem})
 	if err != nil {
 		return err
 	}
 	defer res.Close()
 
 	if !showSystem {
+		// in case the reader doesn't implement WithSystem
 		res.SetFilter(func(r Result) bool {
 			_, ok := w.systemSchemas[r.(*Function).Schema]
 			return !ok
@@ -190,12 +191,13 @@ func (w DefaultWriter) DescribeTableDetails(pattern string, verbose, showSystem 
 	tr, isTR := w.r.(TableReader)
 	_, isCR := w.r.(ColumnReader)
 	if isTR && isCR {
-		res, err := tr.Tables(Filter{Schema: sp, Name: tp})
+		res, err := tr.Tables(Filter{Schema: sp, Name: tp, WithSystem: showSystem})
 		if err != nil {
 			return err
 		}
 		defer res.Close()
 		if !showSystem {
+			// in case the reader doesn't implement WithSystem
 			res.SetFilter(func(r Result) bool {
 				_, ok := w.systemSchemas[r.(*Table).Schema]
 				return !ok
@@ -222,13 +224,14 @@ func (w DefaultWriter) DescribeTableDetails(pattern string, verbose, showSystem 
 	ir, isIR := w.r.(IndexReader)
 	_, isICR := w.r.(IndexColumnReader)
 	if isIR && isICR {
-		res, err := ir.Indexes(Filter{Schema: sp, Name: tp})
+		res, err := ir.Indexes(Filter{Schema: sp, Name: tp, WithSystem: showSystem})
 		if err != nil && err != ErrNotSupported {
 			return err
 		}
 		if res != nil {
 			defer res.Close()
 			if !showSystem {
+				// in case the reader doesn't implement WithSystem
 				res.SetFilter(func(r Result) bool {
 					_, ok := w.systemSchemas[r.(*Index).Schema]
 					return !ok
@@ -254,7 +257,7 @@ func (w DefaultWriter) DescribeTableDetails(pattern string, verbose, showSystem 
 
 func (w DefaultWriter) describeTableDetails(typ, sp, tp string, verbose, showSystem bool) error {
 	r := w.r.(ColumnReader)
-	res, err := r.Columns(Filter{Schema: sp, Parent: tp})
+	res, err := r.Columns(Filter{Schema: sp, Parent: tp, WithSystem: showSystem})
 	if err != nil {
 		return err
 	}
@@ -346,7 +349,7 @@ func (w DefaultWriter) getIndexColumns(c, s, t, i string) (string, error) {
 
 func (w DefaultWriter) describeSequences(sp, tp string, verbose, showSystem bool) (int, error) {
 	r := w.r.(SequenceReader)
-	res, err := r.Sequences(Filter{Schema: sp, Name: tp})
+	res, err := r.Sequences(Filter{Schema: sp, Name: tp, WithSystem: showSystem})
 	if err != nil && err != ErrNotSupported {
 		return 0, err
 	}
@@ -442,12 +445,13 @@ func (w DefaultWriter) ListTables(tableTypes, pattern string, verbose, showSyste
 	if err != nil {
 		return err
 	}
-	res, err := r.Tables(Filter{Schema: sp, Name: tp, Types: types})
+	res, err := r.Tables(Filter{Schema: sp, Name: tp, Types: types, WithSystem: showSystem})
 	if err != nil {
 		return err
 	}
 	defer res.Close()
 	if !showSystem {
+		// in case the reader doesn't implement WithSystem
 		res.SetFilter(func(r Result) bool {
 			_, ok := w.systemSchemas[r.(*Table).Schema]
 			return !ok
@@ -483,13 +487,14 @@ func (w DefaultWriter) ListSchemas(pattern string, verbose, showSystem bool) err
 	if !ok {
 		return fmt.Errorf(text.NotSupportedByDriver, `\d`)
 	}
-	res, err := r.Schemas(Filter{Name: pattern})
+	res, err := r.Schemas(Filter{Name: pattern, WithSystem: showSystem})
 	if err != nil {
 		return err
 	}
 	defer res.Close()
 
 	if !showSystem {
+		// in case the reader doesn't implement WithSystem
 		res.SetFilter(func(r Result) bool {
 			_, ok := w.systemSchemas[r.(*Schema).Schema]
 			return !ok
@@ -510,13 +515,14 @@ func (w DefaultWriter) ListIndexes(pattern string, verbose, showSystem bool) err
 	if err != nil {
 		return err
 	}
-	res, err := r.Indexes(Filter{Schema: sp, Name: tp})
+	res, err := r.Indexes(Filter{Schema: sp, Name: tp, WithSystem: showSystem})
 	if err != nil {
 		return err
 	}
 	defer res.Close()
 
 	if !showSystem {
+		// in case the reader doesn't implement WithSystem
 		res.SetFilter(func(r Result) bool {
 			_, ok := w.systemSchemas[r.(*Index).Schema]
 			return !ok

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -21,6 +21,7 @@ func init() {
 			infos.ColumnsNumericPrecRadix:         "10",
 			infos.FunctionColumnsNumericPrecRadix: "10",
 		}),
+		infos.WithSystemSchemas([]string{"mysql", "information_schema", "performance_schema"}),
 	)
 	drivers.Register("mysql", drivers.Driver{
 		AllowMultilineComments: true,
@@ -45,10 +46,7 @@ func init() {
 		},
 		NewMetadataReader: newReader,
 		NewMetadataWriter: func(db drivers.DB, w io.Writer, opts ...metadata.ReaderOption) metadata.Writer {
-			writerOpts := []metadata.WriterOption{
-				metadata.WithSystemSchemas([]string{"mysql", "information_schema", "performance_schema"}),
-			}
-			return metadata.NewDefaultWriter(newReader(db, opts...), writerOpts...)(db, w)
+			return metadata.NewDefaultWriter(newReader(db, opts...))(db, w)
 		},
 	}, "memsql", "vitess", "tidb")
 }

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -22,6 +22,7 @@ func init() {
 			infos.FunctionColumnsNumericPrecRadix: "10",
 		}),
 		infos.WithSystemSchemas([]string{"mysql", "information_schema", "performance_schema"}),
+		infos.WithCurrentSchema("DATABASE()"),
 	)
 	drivers.Register("mysql", drivers.Driver{
 		AllowMultilineComments: true,

--- a/drivers/oracle/oracle.go
+++ b/drivers/oracle/oracle.go
@@ -109,10 +109,7 @@ func init() {
 		},
 		NewMetadataReader: orameta.NewReader(),
 		NewMetadataWriter: func(db drivers.DB, w io.Writer, opts ...metadata.ReaderOption) metadata.Writer {
-			writerOpts := []metadata.WriterOption{
-				metadata.WithSystemSchemas([]string{"ctxsys", "flows_files", "mdsys", "outln", "sys", "system", "xdb", "xs$null"}),
-			}
-			return metadata.NewDefaultWriter(orameta.NewReader()(db, opts...), writerOpts...)(db, w)
+			return metadata.NewDefaultWriter(orameta.NewReader()(db, opts...))(db, w)
 		},
 	})
 }

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -21,6 +21,7 @@ func init() {
 				infos.ColumnsColumnSize:         "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
 				infos.FunctionColumnsColumnSize: "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
 			}),
+			infos.WithSystemSchemas([]string{"pg_catalog", "pg_toast", "information_schema"}),
 		)
 		return metadata.NewPluginReader(
 			newIS(db, opts...),
@@ -67,10 +68,7 @@ func init() {
 		},
 		NewMetadataReader: newReader,
 		NewMetadataWriter: func(db drivers.DB, w io.Writer, opts ...metadata.ReaderOption) metadata.Writer {
-			writerOpts := []metadata.WriterOption{
-				metadata.WithSystemSchemas([]string{"pg_catalog", "pg_toast", "information_schema"}),
-			}
-			return metadata.NewDefaultWriter(newReader(db, opts...), writerOpts...)(db, w)
+			return metadata.NewDefaultWriter(newReader(db, opts...))(db, w)
 		},
 	}, "cockroachdb", "redshift")
 }

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -22,6 +22,7 @@ func init() {
 				infos.FunctionColumnsColumnSize: "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
 			}),
 			infos.WithSystemSchemas([]string{"pg_catalog", "pg_toast", "information_schema"}),
+			infos.WithCurrentSchema("CURRENT_SCHEMA"),
 		)
 		return metadata.NewPluginReader(
 			newIS(db, opts...),

--- a/drivers/postgres/reader.go
+++ b/drivers/postgres/reader.go
@@ -65,6 +65,9 @@ FROM pg_catalog.pg_class c
 		"n.nspname !~ '^pg_toast'",
 		"pg_catalog.pg_table_is_visible(c.oid)"}
 	vals := []interface{}{}
+	if !f.WithSystem {
+		conds = append(conds, "n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema')")
+	}
 	if f.Schema != "" {
 		vals = append(vals, f.Schema)
 		conds = append(conds, fmt.Sprintf("n.nspname LIKE $%d", len(vals)))

--- a/drivers/postgres/reader.go
+++ b/drivers/postgres/reader.go
@@ -59,11 +59,15 @@ FROM pg_catalog.pg_class c
      LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
      LEFT JOIN pg_catalog.pg_index i ON i.indexrelid = c.oid
      LEFT JOIN pg_catalog.pg_class c2 ON i.indrelid = c2.oid`
-	conds := []string{"c.relkind IN ('i','I','')",
+	conds := []string{
+		"c.relkind IN ('i','I','')",
 		"n.nspname <> 'pg_catalog'",
 		"n.nspname <> 'information_schema'",
 		"n.nspname !~ '^pg_toast'",
-		"pg_catalog.pg_table_is_visible(c.oid)"}
+	}
+	if f.OnlyVisible {
+		conds = append(conds, "pg_catalog.pg_table_is_visible(c.oid)")
+	}
 	vals := []interface{}{}
 	if !f.WithSystem {
 		conds = append(conds, "n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema')")

--- a/drivers/sqlserver/reader.go
+++ b/drivers/sqlserver/reader.go
@@ -61,6 +61,9 @@ JOIN sys.indexes i ON i.object_id = t.object_id
 `
 	conds := []string{}
 	vals := []interface{}{}
+	if f.OnlyVisible {
+		conds = append(conds, "s.name = schema_name()")
+	}
 	if !f.WithSystem {
 		conds = append(conds, "s.name NOT IN ('db_accessadmin', 'db_backupoperator', 'db_datareader', 'db_datawriter', 'db_ddladmin', 'db_denydatareader', 'db_denydatawriter', 'db_owner', 'db_securityadmin', 'INFORMATION_SCHEMA', 'sys')")
 	}
@@ -116,6 +119,9 @@ JOIN sys.types ty ON ty.user_type_id = c.user_type_id
 `
 	conds := []string{}
 	vals := []interface{}{}
+	if f.OnlyVisible {
+		conds = append(conds, "s.name = schema_name()")
+	}
 	if !f.WithSystem {
 		conds = append(conds, "s.name NOT IN ('db_accessadmin', 'db_backupoperator', 'db_datareader', 'db_datawriter', 'db_ddladmin', 'db_denydatareader', 'db_denydatawriter', 'db_owner', 'db_securityadmin', 'INFORMATION_SCHEMA', 'sys')")
 	}

--- a/drivers/sqlserver/reader.go
+++ b/drivers/sqlserver/reader.go
@@ -61,6 +61,9 @@ JOIN sys.indexes i ON i.object_id = t.object_id
 `
 	conds := []string{}
 	vals := []interface{}{}
+	if !f.WithSystem {
+		conds = append(conds, "s.name NOT IN ('db_accessadmin', 'db_backupoperator', 'db_datareader', 'db_datawriter', 'db_ddladmin', 'db_denydatareader', 'db_denydatawriter', 'db_owner', 'db_securityadmin', 'INFORMATION_SCHEMA', 'sys')")
+	}
 	if f.Schema != "" {
 		vals = append(vals, f.Schema)
 		conds = append(conds, "s.name LIKE ?")
@@ -113,6 +116,9 @@ JOIN sys.types ty ON ty.user_type_id = c.user_type_id
 `
 	conds := []string{}
 	vals := []interface{}{}
+	if !f.WithSystem {
+		conds = append(conds, "s.name NOT IN ('db_accessadmin', 'db_backupoperator', 'db_datareader', 'db_datawriter', 'db_ddladmin', 'db_denydatareader', 'db_denydatawriter', 'db_owner', 'db_securityadmin', 'INFORMATION_SCHEMA', 'sys')")
+	}
 	if f.Schema != "" {
 		vals = append(vals, f.Schema)
 		conds = append(conds, "s.name LIKE ?")

--- a/drivers/sqlserver/sqlserver.go
+++ b/drivers/sqlserver/sqlserver.go
@@ -37,6 +37,7 @@ func init() {
 				"INFORMATION_SCHEMA",
 				"sys",
 			}),
+			infos.WithCurrentSchema("schema_name()"),
 		)(db, opts...)
 		mr := &metaReader{
 			LoggingReader: metadata.NewLoggingReader(db, opts...),

--- a/drivers/sqlserver/sqlserver.go
+++ b/drivers/sqlserver/sqlserver.go
@@ -22,7 +22,20 @@ func init() {
 			infos.WithCustomColumns(map[infos.ColumnName]string{
 				infos.FunctionsSecurityType: "''",
 			}),
-		)(db)
+			infos.WithSystemSchemas([]string{
+				"db_accessadmin",
+				"db_backupoperator",
+				"db_datareader",
+				"db_datawriter",
+				"db_ddladmin",
+				"db_denydatareader",
+				"db_denydatawriter",
+				"db_owner",
+				"db_securityadmin",
+				"INFORMATION_SCHEMA",
+				"sys",
+			}),
+		)(db, opts...)
 		mr := &metaReader{
 			LoggingReader: metadata.NewLoggingReader(db, opts...),
 		}
@@ -61,11 +74,7 @@ func init() {
 		},
 		NewMetadataReader: newReader,
 		NewMetadataWriter: func(db drivers.DB, w io.Writer, opts ...metadata.ReaderOption) metadata.Writer {
-			reader := newReader(db, opts...)
-			writerOpts := []metadata.WriterOption{
-				metadata.WithSystemSchemas([]string{"db_accessadmin", "db_backupoperator", "db_datareader", "db_datawriter", "db_ddladmin", "db_denydatareader", "db_denydatawriter", "db_owner", "db_securityadmin", "INFORMATION_SCHEMA", "sys"}),
-			}
-			return metadata.NewDefaultWriter(reader, writerOpts...)(db, w)
+			return metadata.NewDefaultWriter(newReader(db, opts...))(db, w)
 		},
 	})
 }

--- a/drivers/sqlserver/sqlserver.go
+++ b/drivers/sqlserver/sqlserver.go
@@ -4,6 +4,7 @@
 package sqlserver
 
 import (
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -17,6 +18,7 @@ import (
 func init() {
 	newReader := func(db drivers.DB, opts ...metadata.ReaderOption) metadata.Reader {
 		ir := infos.New(
+			infos.WithPlaceholder(func(n int) string { return fmt.Sprintf("@p%d", n) }),
 			infos.WithIndexes(false),
 			infos.WithSequences(false),
 			infos.WithCustomColumns(map[infos.ColumnName]string{


### PR DESCRIPTION
This PR refactors the metadata reader API, replacing all arguments in every reader with a Filter struct. This:
1. unifies all readers,
2. makes it easier to call them, no need to remember the order of arguments
3. will help avoid making breaking changes in the future, when adding new filters

The old naming was inspired by the JDBC API, but there's no real reason to follow it. Changes in tests show that the new naming is simpler to use. It's the last moment to make such breaking changes.

Point 3 is another reason to do this now, as two new filters are being introduced:
1. `WithSystem` - also return system objects
2. `OnlyVisible` - only return objects not visible by default (not in the search path / current schema)

`WithSystem` and `OnlyVisible` are required for #189 