### PR TITLE
Enable metadata reader for Snowflake

### DIFF
--- a/drivers/snowflake/snowflake.go
+++ b/drivers/snowflake/snowflake.go
@@ -24,6 +24,9 @@ func init() {
 	gosnowflake.SetLogger(&l)
 	newReader := infos.New(
 		infos.WithPlaceholder(func(int) string { return "?" }),
+		infos.WithCustomColumns(map[infos.ColumnName]string{
+			infos.SequenceColumnsIncrement: "''",
+		}),
 		infos.WithFunctions(false),
 		infos.WithIndexes(false),
 	)

--- a/drivers/snowflake/snowflake.go
+++ b/drivers/snowflake/snowflake.go
@@ -4,12 +4,17 @@
 package snowflake
 
 import (
+	"io"
 	"io/ioutil"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
 	"github.com/snowflakedb/gosnowflake" // DRIVER: snowflake
+	"github.com/xo/tblfmt"
 	"github.com/xo/usql/drivers"
+	"github.com/xo/usql/drivers/metadata"
+	infos "github.com/xo/usql/drivers/metadata/informationschema"
+	"github.com/xo/usql/env"
 )
 
 func init() {
@@ -17,12 +22,26 @@ func init() {
 	r.Out, r.Level = ioutil.Discard, logrus.PanicLevel
 	var l gosnowflake.SFLogger = &logger{r}
 	gosnowflake.SetLogger(&l)
+	newReader := infos.New(
+		infos.WithPlaceholder(func(int) string { return "?" }),
+		infos.WithFunctions(false),
+		infos.WithIndexes(false),
+	)
 	drivers.Register("snowflake", drivers.Driver{
 		Err: func(err error) (string, string) {
 			if e, ok := err.(*gosnowflake.SnowflakeError); ok {
 				return strconv.Itoa(e.Number), e.Message
 			}
 			return "", err.Error()
+		},
+		NewMetadataReader: newReader,
+		NewMetadataWriter: func(db drivers.DB, w io.Writer, opts ...metadata.ReaderOption) metadata.Writer {
+			writerOpts := []metadata.WriterOption{
+				metadata.WithListAllDbs(func(pattern string, verbose bool) error {
+					return listAllDbs(db, w, pattern, verbose)
+				}),
+			}
+			return metadata.NewDefaultWriter(newReader(db, opts...), writerOpts...)(db, w)
 		},
 	})
 }
@@ -33,3 +52,15 @@ type logger struct {
 }
 
 func (*logger) SetLogLevel(string) error { return nil }
+
+func listAllDbs(db drivers.DB, w io.Writer, pattern string, verbose bool) error {
+	rows, err := db.Query("SHOW databases")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	params := env.Pall()
+	params["title"] = "List of databases"
+	return tblfmt.EncodeAll(w, rows, params)
+}


### PR DESCRIPTION
Tested manually, requires to have a database and warehouse selected, using `use database` and `use warehouse`.

Tables names are stores in uppercase. We might want to handle this, but I don't think we need to in this PR.

There's actually a `information_schema.databases` table/view available so maybe it's a good moment to implement (an optional, disabled by default) `Catalogs()`?