### PR TITLE
Complete files for usql commands

### DIFF
--- a/drivers/completer/completer_test.go
+++ b/drivers/completer/completer_test.go
@@ -47,6 +47,16 @@ func TestCompleter(t *testing.T) {
 			3,
 		},
 		{
+			"files",
+			`\i comp`,
+			7,
+			[]string{
+				"leter.go",
+				"leter_test.go",
+			},
+			4,
+		},
+		{
 			"3rd word",
 			"SELECT * F",
 			10,


### PR DESCRIPTION
Closes #41 but doesn't handle quoted paths well. Also fixes an issue with matching multi-word patterns, so JOINs will be completed now.