### PR TITLE
Handle SIGINT during opening a connection

### DIFF
--- a/drivers/athena/athena.go
+++ b/drivers/athena/athena.go
@@ -4,6 +4,7 @@
 package athena
 
 import (
+	"context"
 	"regexp"
 
 	_ "github.com/uber/athenadriver/go" // DRIVER: athena
@@ -19,9 +20,10 @@ func init() {
 			typ, q := drivers.QueryExecType(prefix, sqlstr)
 			return typ, sqlstr, q, nil
 		},
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
-			err := db.QueryRow(
+			err := db.QueryRowContext(
+				ctx,
 				`SELECT node_version FROM system.runtime.nodes LIMIT 1`,
 			).Scan(&ver)
 			if err != nil {

--- a/drivers/cassandra/cassandra.go
+++ b/drivers/cassandra/cassandra.go
@@ -4,6 +4,7 @@
 package cassandra
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -80,9 +81,10 @@ func init() {
 			gocql.Logger, cql.CqlDriver.Logger = l, log.New(l, "", 0)
 			return sql.Open, nil
 		},
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var release, protocol, cql string
-			err := db.QueryRow(
+			err := db.QueryRowContext(
+				ctx,
 				`SELECT release_version, cql_version, native_protocol_version FROM system.local WHERE key = 'local'`,
 			).Scan(&release, &cql, &protocol)
 			if err != nil {

--- a/drivers/firebird/firebird.go
+++ b/drivers/firebird/firebird.go
@@ -4,6 +4,8 @@
 package firebird
 
 import (
+	"context"
+
 	_ "github.com/nakagami/firebirdsql" // DRIVER: firebirdsql
 	"github.com/xo/usql/drivers"
 )
@@ -11,9 +13,12 @@ import (
 func init() {
 	drivers.Register("firebirdsql", drivers.Driver{
 		AllowMultilineComments: true,
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
-			err := db.QueryRow(`SELECT rdb$get_context('SYSTEM', 'ENGINE_VERSION') FROM rdb$database;`).Scan(&ver)
+			err := db.QueryRowContext(
+				ctx,
+				`SELECT rdb$get_context('SYSTEM', 'ENGINE_VERSION') FROM rdb$database;`,
+			).Scan(&ver)
 			if err != nil {
 				return "", err
 			}

--- a/drivers/godror/godror.go
+++ b/drivers/godror/godror.go
@@ -5,6 +5,7 @@
 package godror
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io"
@@ -37,17 +38,17 @@ func init() {
 				}
 			}
 		},
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
-			err := db.QueryRow(`SELECT version FROM v$instance`).Scan(&ver)
+			err := db.QueryRowContext(ctx, `SELECT version FROM v$instance`).Scan(&ver)
 			if err != nil {
 				return "", err
 			}
 			return "Oracle Database " + ver, nil
 		},
-		User: func(db drivers.DB) (string, error) {
+		User: func(ctx context.Context, db drivers.DB) (string, error) {
 			var user string
-			err := db.QueryRow(`SELECT user FROM dual`).Scan(&user)
+			err := db.QueryRowContext(ctx, `SELECT user FROM dual`).Scan(&user)
 			return user, err
 		},
 		ChangePassword: func(db drivers.DB, user, newpw, _ string) error {

--- a/drivers/moderncsqlite/moderncsqlite.go
+++ b/drivers/moderncsqlite/moderncsqlite.go
@@ -5,6 +5,7 @@
 package moderncsqlite
 
 import (
+	"context"
 	"database/sql"
 	"strconv"
 	"strings"
@@ -23,9 +24,9 @@ func init() {
 				return sql.Open("sqlite", params)
 			}, nil
 		},
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
-			err := db.QueryRow(`SELECT sqlite_version()`).Scan(&ver)
+			err := db.QueryRowContext(ctx, `SELECT sqlite_version()`).Scan(&ver)
 			if err != nil {
 				return "", err
 			}

--- a/drivers/netezza/netezza.go
+++ b/drivers/netezza/netezza.go
@@ -4,6 +4,7 @@
 package netezza
 
 import (
+	"context"
 	"io"
 
 	"github.com/IBM/nzgo" // DRIVER: nzgo
@@ -33,9 +34,9 @@ func init() {
 		AllowDollar:            true,
 		AllowMultilineComments: true,
 		LexerName:              "postgres",
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
-			err := db.QueryRow(`SELECT version()`).Scan(&ver)
+			err := db.QueryRowContext(ctx, `SELECT version()`).Scan(&ver)
 			if err != nil {
 				return "", err
 			}

--- a/drivers/oracle/oracle.go
+++ b/drivers/oracle/oracle.go
@@ -4,6 +4,7 @@
 package oracle
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io"
@@ -36,17 +37,17 @@ func init() {
 				}
 			}
 		},
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
-			err := db.QueryRow(`SELECT version FROM v$instance`).Scan(&ver)
+			err := db.QueryRowContext(ctx, `SELECT version FROM v$instance`).Scan(&ver)
 			if err != nil {
 				return "", err
 			}
 			return "Oracle Database " + ver, nil
 		},
-		User: func(db drivers.DB) (string, error) {
+		User: func(ctx context.Context, db drivers.DB) (string, error) {
 			var user string
-			err := db.QueryRow(`SELECT user FROM dual`).Scan(&user)
+			err := db.QueryRowContext(ctx, `SELECT user FROM dual`).Scan(&user)
 			return user, err
 		},
 		ChangePassword: func(db drivers.DB, user, newpw, _ string) error {

--- a/drivers/pgx/pgx.go
+++ b/drivers/pgx/pgx.go
@@ -4,6 +4,7 @@
 package pgx
 
 import (
+	"context"
 	"errors"
 
 	"github.com/jackc/pgconn"
@@ -16,9 +17,9 @@ func init() {
 		AllowDollar:            true,
 		AllowMultilineComments: true,
 		LexerName:              "postgres",
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
-			err := db.QueryRow(`SHOW server_version`).Scan(&ver)
+			err := db.QueryRowContext(ctx, `SHOW server_version`).Scan(&ver)
 			if err != nil {
 				return "", err
 			}

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -4,6 +4,7 @@
 package postgres
 
 import (
+	"context"
 	"io"
 
 	"github.com/lib/pq" // DRIVER: postgres
@@ -41,11 +42,11 @@ func init() {
 				drivers.ForceQueryParameters([]string{"sslmode", "disable"})(u)
 			}
 		},
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			// numeric version
 			// SHOW server_version_num;
 			var ver string
-			err := db.QueryRow(`SHOW server_version`).Scan(&ver)
+			err := db.QueryRowContext(ctx, `SHOW server_version`).Scan(&ver)
 			if err != nil {
 				return "", err
 			}

--- a/drivers/presto/presto.go
+++ b/drivers/presto/presto.go
@@ -4,6 +4,7 @@
 package presto
 
 import (
+	"context"
 	"regexp"
 
 	_ "github.com/prestodb/presto-go-client/presto" // DRIVER: presto
@@ -19,9 +20,10 @@ func init() {
 			typ, q := drivers.QueryExecType(prefix, sqlstr)
 			return typ, sqlstr, q, nil
 		},
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
-			err := db.QueryRow(
+			err := db.QueryRowContext(
+				ctx,
 				`SELECT node_version FROM system.runtime.nodes LIMIT 1`,
 			).Scan(&ver)
 			if err != nil {

--- a/drivers/sapase/sapase.go
+++ b/drivers/sapase/sapase.go
@@ -4,6 +4,7 @@
 package sapase
 
 import (
+	"context"
 	"errors"
 	"regexp"
 	"strconv"
@@ -19,9 +20,9 @@ func init() {
 		AllowMultilineComments:  true,
 		RequirePreviousPassword: true,
 		LexerName:               "tsql",
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
-			err := db.QueryRow(`SELECT @@version`).Scan(&ver)
+			err := db.QueryRowContext(ctx, `SELECT @@version`).Scan(&ver)
 			if err != nil {
 				return "", err
 			}

--- a/drivers/saphana/saphana.go
+++ b/drivers/saphana/saphana.go
@@ -4,6 +4,7 @@
 package saphana
 
 import (
+	"context"
 	"strconv"
 
 	_ "github.com/SAP/go-hdb/driver" // DRIVER: hdb
@@ -13,9 +14,9 @@ import (
 func init() {
 	drivers.Register("hdb", drivers.Driver{
 		AllowMultilineComments: true,
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
-			if err := db.QueryRow(`SELECT version FROM m_database`).Scan(&ver); err != nil {
+			if err := db.QueryRowContext(ctx, `SELECT version FROM m_database`).Scan(&ver); err != nil {
 				return "", err
 			}
 			return "SAP HANA " + ver, nil

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -4,6 +4,7 @@
 package sqlite3
 
 import (
+	"context"
 	"strconv"
 	"strings"
 
@@ -24,9 +25,9 @@ func init() {
 		ForceParams: drivers.ForceQueryParameters([]string{
 			"loc", "auto",
 		}),
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
-			err := db.QueryRow(`SELECT sqlite_version()`).Scan(&ver)
+			err := db.QueryRowContext(ctx, `SELECT sqlite_version()`).Scan(&ver)
 			if err != nil {
 				return "", err
 			}

--- a/drivers/sqlserver/sqlserver.go
+++ b/drivers/sqlserver/sqlserver.go
@@ -4,6 +4,7 @@
 package sqlserver
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strconv"
@@ -48,9 +49,10 @@ func init() {
 		AllowMultilineComments:  true,
 		RequirePreviousPassword: true,
 		LexerName:               "tsql",
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver, level, edition string
-			err := db.QueryRow(
+			err := db.QueryRowContext(
+				ctx,
 				`SELECT SERVERPROPERTY('productversion'), SERVERPROPERTY ('productlevel'), SERVERPROPERTY ('edition')`,
 			).Scan(&ver, &level, &edition)
 			if err != nil {

--- a/drivers/trino/trino.go
+++ b/drivers/trino/trino.go
@@ -4,6 +4,7 @@
 package trino
 
 import (
+	"context"
 	"io"
 	"regexp"
 
@@ -36,9 +37,10 @@ func init() {
 			typ, q := drivers.QueryExecType(prefix, sqlstr)
 			return typ, sqlstr, q, nil
 		},
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
-			err := db.QueryRow(
+			err := db.QueryRowContext(
+				ctx,
 				`SELECT node_version FROM system.runtime.nodes LIMIT 1`,
 			).Scan(&ver)
 			if err != nil {

--- a/drivers/vertica/vertica.go
+++ b/drivers/vertica/vertica.go
@@ -4,6 +4,7 @@
 package vertica
 
 import (
+	"context"
 	"os"
 	"regexp"
 	"strings"
@@ -22,9 +23,9 @@ func init() {
 	drivers.Register("vertica", drivers.Driver{
 		AllowDollar:            true,
 		AllowMultilineComments: true,
-		Version: func(db drivers.DB) (string, error) {
+		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
-			if err := db.QueryRow(`SELECT version()`).Scan(&ver); err != nil {
+			if err := db.QueryRowContext(ctx, `SELECT version()`).Scan(&ver); err != nil {
 				return "", err
 			}
 			return ver, nil

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ package main
 //go:generate ./gen-license.sh
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -111,7 +112,7 @@ func run(args *Args, u *user.User) error {
 		}
 	}
 	// open dsn
-	if err = h.Open(dsn); err != nil {
+	if err = h.Open(context.Background(), dsn); err != nil {
 		return err
 	}
 	// start transaction

--- a/metacmd/cmds.go
+++ b/metacmd/cmds.go
@@ -2,10 +2,12 @@ package metacmd
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
+	"os/signal"
 	"sort"
 	"strconv"
 	"strings"
@@ -130,7 +132,10 @@ func init() {
 				if err != nil {
 					return err
 				}
-				return p.Handler.Open(vals...)
+				ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+				err = p.Handler.Open(ctx, vals...)
+				stop()
+				return err
 			},
 		},
 		Disconnect: {

--- a/metacmd/types.go
+++ b/metacmd/types.go
@@ -1,6 +1,7 @@
 package metacmd
 
 import (
+	"context"
 	"io"
 	"os/user"
 	"strings"
@@ -34,7 +35,7 @@ type Handler interface {
 	// Reset resets the last and current query buffer.
 	Reset([]rune)
 	// Open opens a database connection.
-	Open(...string) error
+	Open(context.Context, ...string) error
 	// Close closes the current database connection.
 	Close() error
 	// ChangePassword changes the password for a user.


### PR DESCRIPTION
I noticed that when running the `\c` command with an invalid host, when I press `CTRL+C` then `usql` quits. This PR adds a context that's being closed on SIGINT.

Unfortunately, the `Open()` function from `database/sql` package doesn't use a context. We do call `Ping()` right after it, so I'm passing the context there. But some drivers, notably `libpq`, perform blocking operations when calling `Open()`, like dialing. This can block for the duration of `connect_timeout`. Adding a context to handle SIGINT means `usql` cannot be interrupted at all. `pgx` behaves correctly. Can I suggest that we make `pgx` the default driver for `postgres://`, especially since `libpq` is in maintenance mode?

Another solution is to also pass the context to the `driver.Open` callback, define `Open()` for the `postgres` driver and make it panic when context gets closed.

Closes #201 