### PR TITLE
Bump Netezza (nzgo) version and use correct system schema names

### DIFF
--- a/drivers/netezza/netezza.go
+++ b/drivers/netezza/netezza.go
@@ -25,7 +25,7 @@ func init() {
 			infos.ColumnsColumnSize:         "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
 			infos.FunctionColumnsColumnSize: "COALESCE(character_maximum_length, numeric_precision, datetime_precision, interval_precision, 0)",
 		}),
-		infos.WithSystemSchemas([]string{"definition_schema", "information_schema"}),
+		infos.WithSystemSchemas([]string{"DEFINITION_SCHEMA", "INFORMATION_SCHEMA"}),
 		infos.WithCurrentSchema("CURRENT_SCHEMA"),
 	)
 	drivers.Register("nzgo", drivers.Driver{

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/spanner v1.17.0 // indirect
 	github.com/ClickHouse/clickhouse-go v1.4.3
 	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
-	github.com/IBM/nzgo v11.1.0+incompatible
+	github.com/IBM/nzgo v0.0.0-20210406171630-186d127e2795
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/MichaelS11/go-cql-driver v0.1.1
 	github.com/Microsoft/hcsshim v0.8.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/ClickHouse/clickhouse-go v1.4.3/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHg
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/IBM/nzgo v11.1.0+incompatible h1:CaaDdlBodPo+ZiHuMMWBpfSQlSH88/nxCzsdCnQRbAA=
-github.com/IBM/nzgo v11.1.0+incompatible/go.mod h1:n1QK6KJjNa8fe+HQPynW+mJpRpkffLXMO8LR9Nja0JU=
+github.com/IBM/nzgo v0.0.0-20210406171630-186d127e2795 h1:W9EhSwnh9MrP4MW89gKCoe/t59uZkDL3bGMTirPyvyI=
+github.com/IBM/nzgo v0.0.0-20210406171630-186d127e2795/go.mod h1:n1QK6KJjNa8fe+HQPynW+mJpRpkffLXMO8LR9Nja0JU=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=


### PR DESCRIPTION
The latest version fixes two serious issues:
* appending a null byte to all strings
* not being able to execute queries with bound params, this is required for `\d*` commands to work

Since `\d` commands work now, I noticed that the system schemas were included by default, because of incorrect case.