### PR TITLE
Correctly parse fieldsep flags

### DIFF
--- a/args.go
+++ b/args.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/alecthomas/kingpin"
 	"github.com/xo/usql/text"
@@ -66,7 +67,11 @@ type pset struct {
 }
 
 func (p pset) Set(value string) error {
-	p.vals[0] = fmt.Sprintf(p.vals[0], value[0])
+	for i, v := range p.vals {
+		if strings.ContainsRune(v, '%') {
+			p.vals[i] = fmt.Sprintf(v, value)
+		}
+	}
 	p.args.PVariables = append(p.args.PVariables, p.vals...)
 	return nil
 }
@@ -97,8 +102,8 @@ func NewArgs() *Args {
 	// pset
 	kingpin.Flag("pset", `set printing option VAR to ARG (see \pset command)`).Short('P').PlaceHolder("VAR[=ARG]").StringsVar(&args.PVariables)
 	// pset flags
-	kingpin.Flag("field-separator", `field separator for unaligned output (default, "|")`).Short('F').SetValue(pset{args, []string{"fieldsep=%q", "fieldsep_zero=off"}})
-	kingpin.Flag("record-separator", `record separator for unaligned output (default, \n)`).Short('R').SetValue(pset{args, []string{"recordsep=%q", "recordsep_zero=off"}})
+	kingpin.Flag("field-separator", `field separator for unaligned and CSV output (default "|" and ",")`).Short('F').SetValue(pset{args, []string{"fieldsep=%q", "csv_fieldsep=%q"}})
+	kingpin.Flag("record-separator", `record separator for unaligned and CSV output (default \n)`).Short('R').SetValue(pset{args, []string{"recordsep=%q"}})
 	kingpin.Flag("table-attr", "set HTML table tag attributes (e.g., width, border)").Short('T').SetValue(pset{args, []string{"tableattr=%q"}})
 	type psetconfig struct {
 		long  string
@@ -114,8 +119,8 @@ func NewArgs() *Args {
 		pc("html", 'H', "HTML table output mode", "format=html"),
 		pc("tuples-only", 't', "print rows only", "tuples_only=on"),
 		pc("expanded", 'x', "turn on expanded table output", "expanded=on"),
-		pc("field-separator-zero", 'z', "set field separator for unaligned output to zero byte", "fieldsep=''", "fieldsep_zero=on"),
-		pc("record-separator-zero", '0', "set record separator for unaligned output to zero byte", "recordsep=''", "recordsep_zero=on"),
+		pc("field-separator-zero", 'z', "set field separator for unaligned and CSV output to zero byte", "fieldsep_zero=on"),
+		pc("record-separator-zero", '0', "set record separator for unaligned and CSV output to zero byte", "recordsep_zero=on"),
 		pc("json", 'J', "JSON output mode", "format=json"),
 		pc("csv", 'C', "CSV output mode", "format=csv"),
 		pc("vertical", 'G', "vertical output mode", "format=vertical"),

--- a/main.go
+++ b/main.go
@@ -85,7 +85,15 @@ func run(args *Args, u *user.User) error {
 	}
 	for _, v := range args.PVariables {
 		if i := strings.Index(v, "="); i != -1 {
-			if _, err = env.Pset(v[:i], v[i+1:]); err != nil {
+			vv := v[i+1:]
+			if c := vv[0]; c == '\'' || c == '"' {
+				var err error
+				vv, err = env.Dequote(vv, c)
+				if err != nil {
+					return err
+				}
+			}
+			if _, err = env.Pset(v[:i], vv); err != nil {
 				return err
 			}
 		} else {


### PR DESCRIPTION
Make the `field-separator` flag set both `fieldsep` and `csv_fieldsep` options. Also fix dequoting pset variables set from cli flags. Also, `fieldsep` can never be set to an empty string. Latest changes in `tblfmt` prevent this.

Closes #224 