### PR TITLE
Implement quiet setting

### DIFF
--- a/args.go
+++ b/args.go
@@ -133,6 +133,10 @@ func NewArgs() *Args {
 			return nil
 		}).Bool()
 	}
+	kingpin.Flag("quiet", "run quietly (no messages, only query output)").Short('q').PreAction(func(*kingpin.ParseContext) error {
+		args.Variables = append(args.Variables, "QUIET=on")
+		return nil
+	}).Bool()
 	// add --set as a hidden alias for --variable
 	kingpin.Flag("variable", "set variable NAME to VALUE").Hidden().StringsVar(&args.Variables)
 	// add --version flag

--- a/env/types.go
+++ b/env/types.go
@@ -103,8 +103,20 @@ func ValidIdentifier(n string) error {
 
 // Set sets a variable.
 func Set(name, value string) error {
-	if err := ValidIdentifier(name); err != nil {
+	err := ValidIdentifier(name)
+	if err != nil {
 		return err
+	}
+	switch name {
+	case "QUIET":
+		if value == "" {
+			value = "on"
+		} else {
+			value, err = ParseBool(value, name)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	vars.Set(name, value)
 	return nil
@@ -191,6 +203,10 @@ func ParseKeywordBool(value, name string, keywords ...string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf(text.FormatFieldInvalid, value, name)
+}
+
+func Get(name string) string {
+	return vars[name]
 }
 
 func Pget(name string) (string, error) {

--- a/metacmd/cmds.go
+++ b/metacmd/cmds.go
@@ -67,9 +67,7 @@ func init() {
 			Name:    "copyright",
 			Desc:    "show " + text.CommandName + " usage and distribution terms",
 			Process: func(p *Params) error {
-				out := p.Handler.IO().Stdout()
-				fmt.Fprintln(out, text.Copyright)
-				fmt.Fprintln(out)
+				p.Handler.Print(text.Copyright)
 				return nil
 			},
 		},
@@ -78,12 +76,10 @@ func init() {
 			Name:    "conninfo",
 			Desc:    "display information about the current database connection",
 			Process: func(p *Params) error {
-				out := p.Handler.IO().Stdout()
 				if db, u := p.Handler.DB(), p.Handler.URL(); db != nil && u != nil {
-					fmt.Fprintf(out, text.ConnInfo, u.Driver, u.DSN)
-					fmt.Fprintln(out)
+					p.Handler.Print(text.ConnInfo, u.Driver, u.DSN)
 				} else {
-					fmt.Fprintln(out, text.NotConnected)
+					p.Handler.Print(text.NotConnected)
 				}
 				return nil
 			},
@@ -164,8 +160,7 @@ func init() {
 				case err != nil:
 					return fmt.Errorf(text.PasswordChangeFailed, user, err)
 				}
-				/*fmt.Fprintf(p.Handler.IO().Stdout(), text.PasswordChangeSucceeded, user)
-				fmt.Fprintln(p.Handler.IO().Stdout())*/
+				//p.Handler.Print(text.PasswordChangeSucceeded, user)
 				return nil
 			},
 		},
@@ -435,9 +430,7 @@ func init() {
 				if p.Handler.GetTiming() {
 					setting = "on"
 				}
-				out := p.Handler.IO().Stdout()
-				fmt.Fprintf(out, text.TimingSet, setting)
-				fmt.Fprintln(out)
+				p.Handler.Print(text.TimingSet, setting)
 				return nil
 			},
 		},
@@ -667,19 +660,17 @@ func init() {
 				// format output
 				mask := text.FormatFieldNameSetMap[field]
 				unsetMask := text.FormatFieldNameUnsetMap[field]
-				out := p.Handler.IO().Stdout()
 				switch {
 				case strings.Contains(mask, "%d"):
 					i, _ := strconv.Atoi(val)
-					fmt.Fprintf(out, mask, i)
+					p.Handler.Print(mask, i)
 				case unsetMask != "" && val == "":
-					fmt.Fprint(out, unsetMask)
+					p.Handler.Print(unsetMask)
 				case !strings.Contains(mask, "%"):
-					fmt.Fprint(out, mask)
+					p.Handler.Print(mask)
 				default:
-					fmt.Fprintf(out, mask, val)
+					p.Handler.Print(mask, val)
 				}
-				fmt.Fprintln(out)
 				return nil
 			},
 		},

--- a/metacmd/types.go
+++ b/metacmd/types.go
@@ -62,6 +62,8 @@ type Handler interface {
 	SetOutput(io.WriteCloser)
 	// MetadataWriter retrieves the metadata writer for the handler.
 	MetadataWriter() (metadata.Writer, error)
+	// Print formats according to a format specifier and writes to handler's standard output.
+	Print(string, ...interface{})
 }
 
 // Runner is a runner interface type.


### PR DESCRIPTION
There are slight differences with how it's implemented in `psql`. For example, `QUIET` can be unset in `usql`, but it's set to `off` in `psql`.

Closes #221 