### PR TITLE
Complete MySQL tables without db selected

### DIFF
--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -461,7 +461,7 @@ func NewMetadataWriter(u *dburl.URL, db DB, w io.Writer, opts ...metadata.Reader
 	return newMetadataWriter(db, w), nil
 }
 
-func NewCompleter(u *dburl.URL, db DB, opts ...completer.Option) readline.AutoCompleter {
+func NewCompleter(u *dburl.URL, db DB, readerOpts []metadata.ReaderOption, opts ...completer.Option) readline.AutoCompleter {
 	d, ok := drivers[u.Driver]
 	if !ok {
 		return nil
@@ -472,14 +472,14 @@ func NewCompleter(u *dburl.URL, db DB, opts ...completer.Option) readline.AutoCo
 	if d.NewMetadataReader == nil {
 		return nil
 	}
-	r := d.NewMetadataReader(db,
+	// prepend to allow to override default options
+	readerOpts = append([]metadata.ReaderOption{
 		// this needs to be relatively low, since autocomplete is very interactive
-		metadata.WithTimeout(3*time.Second),
+		metadata.WithTimeout(3 * time.Second),
 		metadata.WithLimit(1000),
-	)
-	// prepend to allow to override both reader and db
+	}, readerOpts...)
 	opts = append([]completer.Option{
-		completer.WithReader(r),
+		completer.WithReader(d.NewMetadataReader(db, readerOpts...)),
 		completer.WithDB(db),
 	}, opts...)
 	return completer.NewDefaultCompleter(opts...)

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -26,7 +26,7 @@ func init() {
 			infos.ConstraintJoinCond:              "AND r.table_name = f.table_name",
 		}),
 		infos.WithSystemSchemas([]string{"mysql", "information_schema", "performance_schema", "sys"}),
-		infos.WithCurrentSchema("DATABASE()"),
+		infos.WithCurrentSchema("COALESCE(DATABASE(), '%')"),
 	)
 	drivers.Register("mysql", drivers.Driver{
 		AllowMultilineComments: true,

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -564,7 +564,7 @@ func (h *Handler) Open(ctx context.Context, params ...string) error {
 	// force error/check connection
 	if err == nil {
 		if err = drivers.Ping(ctx, h.u, h.db); err == nil {
-			h.l.Completer(drivers.NewCompleter(h.u, h.db, completer.WithConnStrings(connStrings)))
+			h.l.Completer(drivers.NewCompleter(h.u, h.db, readerOptions(), completer.WithConnStrings(connStrings)))
 			return h.Version(ctx)
 		}
 	}
@@ -1169,6 +1169,11 @@ func (h *Handler) MetadataWriter() (metadata.Writer, error) {
 	if h.db == nil {
 		return nil, text.ErrNotConnected
 	}
+	opts := readerOptions()
+	return drivers.NewMetadataWriter(h.u, h.db, h.l.Stdout(), opts...)
+}
+
+func readerOptions() []metadata.ReaderOption {
 	var opts []metadata.ReaderOption
 	envs := env.All()
 	if envs["ECHO_HIDDEN"] == "on" || envs["ECHO_HIDDEN"] == "noexec" {
@@ -1181,7 +1186,7 @@ func (h *Handler) MetadataWriter() (metadata.Writer, error) {
 			metadata.WithTimeout(30*time.Second),
 		)
 	}
-	return drivers.NewMetadataWriter(h.u, h.db, h.l.Stdout(), opts...)
+	return opts
 }
 
 // GetOutput gets the output writer.


### PR DESCRIPTION
Completer only returns objects in the current schema by adding a condition like `table_schema LIKE DATABASE()`. Turns out it's possible to connect to MySQL without any database and `DATABASE()` returns a NULL, which prevents the query from returning any names.

This PR also includes a change to make completer recognize `ECHO_HIDDEN` so it's easier to debug its queries.

Closes #239 