### PR TITLE
Avoid panic when interpolating variables

### DIFF
--- a/stmt/stmt.go
+++ b/stmt/stmt.go
@@ -102,7 +102,9 @@ func (b *Stmt) RawString() string {
 		if v.Len == 0 {
 			continue
 		}
-		z.WriteString(s[i:v.I])
+		if len(s) > i {
+			z.WriteString(s[i:v.I])
+		}
 		if v.Quote != '\\' {
 			z.WriteRune(':')
 		}
@@ -116,7 +118,9 @@ func (b *Stmt) RawString() string {
 		i = v.I + v.Len
 	}
 	// add remaining
-	z.WriteString(s[i:])
+	if len(s) > i {
+		z.WriteString(s[i:])
+	}
 	return z.String()
 }
 


### PR DESCRIPTION
Avoid panic when interpolating variables, where variable contents are longer than the query in which they're used.