### PR TITLE
Unescape special chars in params

### DIFF
--- a/stmt/parse.go
+++ b/stmt/parse.go
@@ -90,6 +90,10 @@ func readString(r []rune, i, end int, quote rune, tag string) (int, bool) {
 	for ; i < end; i++ {
 		c, next = r[i], grab(r, i+1, end)
 		switch {
+		case quote == '\'' && c == '\\':
+			i++
+			prev = 0
+			continue
 		case quote == '\'' && c == '\'' && next == '\'':
 		case quote == '\'' && c == '\'' && prev != '\'',
 			quote == '"' && c == '"',


### PR DESCRIPTION
Partially addresses #166 by unescaping special characters, including quotes. This allows to use of variables as aliases for long/complex queries that contain quoted literals, like so:
```
\set activity 'select pid,now()-query_start,substring(query for 60) || \'...\' || substring(query from length(query)-40) from pg_stat_activity where state = \'active\' order by query_start desc;'
```
or use special chars in commands:
```
\echo '\nWelcome, my magistrate\n'
```

This does NOT address any escaping done when quoting vars, per `testdata/quotes.sql`.