### PR TITLE
Remove unnecessary build flags

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -14,9 +14,6 @@ TAGS=(
   sqlite_stat4
   sqlite_userauth
   sqlite_vtable
-  osusergo
-  netgo
-  static_build
 )
 
 # get latest tag version
@@ -65,11 +62,11 @@ echo "BUILDING:    $BIN"
 # build parameters
 TAGS="${TAGS[@]}"
 EXTLDFLAGS=(
-  -fno-PIC
   -static
   -licuuc
   -licui18n
   -licudata
+  -lm
   -ldl
 )
 EXTLDFLAGS="${EXTLDFLAGS[@]}"
@@ -94,8 +91,6 @@ log() {
 (set -x;
   go build \
     -tags="$TAGS" \
-    -gccgoflags="all=-DU_STATIC_IMPLEMENTATION" \
-    -buildmode=pie \
     -ldflags="$LDFLAGS" \
     -o $BIN
 ) 2>&1 | log 'BUILDING:    '


### PR DESCRIPTION
I ran some more tests and figured out the minimum set of changes required to have static builds. I suggest we revert adding `osusergo` and `netgo` flags, as we don't need _fully_ static binaries. Go implementations can be limited and this can cause suble bugs in some drivers that may rely on the specific behavior of glibc.

I also suggest to remove `-fno-PIC` and `-buildmode=pie` until we know why we would need a PIE.

I also suggest adding `-lm` since this is mentioned in some `sqlite3` extensions, see here: https://github.com/mattn/go-sqlite3/blob/master/sqlite3_opt_fts5.go

I don't think we need to mess with any CFLAGS, the ones defined in `go-sqlite3` will still be used. The reason we had to re-define linker flags is that they need to go after `-static`. Relevant part from the manual:
```
 -static
           Do not link against shared libraries.  (...) You may use this option multiple times on the command line: it affects library searching for -l options which follow it. (...)
```

Lastly, `-gccgoflags="all=-DU_STATIC_IMPLEMENTATION"` doesn't seem to be needed, ICU works in SQLite without it.

I've tested this using a scratch image build from:
```docker
FROM centos as base

RUN echo root::0:0::/:/bin/bash > /tmp/passwd

FROM scratch

COPY --from=base /tmp/passwd /etc/passwd
```

and then I ran these commands to ensure that ICU in SQLite3 works and network connections also work:
```bash
docker run --rm -it -v $(pwd)/build/linux/0.9.0/:/app empty /app/usql -v SHOW_HOST_INFORMATION=false -X -A -P tuples_only=on \
  sqlite3://:memory: \
  -c "select lower('I', 'tr_tr') as a"
docker run --rm -it -v $(pwd)/build/linux/0.9.0/:/app empty /app/usql -v SHOW_HOST_INFORMATION=false -X -A -P tuples_only=on \
  'pg://postgres:pw@10.0.2.15:49153/postgres?sslmode=disable' \
  -c "select count(*) from pg_class"
```

