### PR TITLE
Use correct DB.Open() in drivers tests

### DIFF
--- a/drivers/metadata/informationschema/metadata_test.go
+++ b/drivers/metadata/informationschema/metadata_test.go
@@ -45,7 +45,7 @@ var (
 		"pgsql": {
 			BuildArgs: []dc.BuildArg{
 				{Name: "BASE_IMAGE", Value: "postgres:13"},
-				{Name: "SCHEMA_URL", Value: "https://raw.githubusercontent.com/jOOQ/jOOQ/main/jOOQ-examples/Sakila/postgres-sakila-db/postgres-sakila-schema.sql"},
+				{Name: "SCHEMA_URL", Value: "https://raw.githubusercontent.com/jOOQ/sakila/main/postgres-sakila-db/postgres-sakila-schema.sql"},
 				{Name: "TARGET", Value: "/docker-entrypoint-initdb.d"},
 				{Name: "USER", Value: "root"},
 			},
@@ -69,7 +69,7 @@ var (
 		"mysql": {
 			BuildArgs: []dc.BuildArg{
 				{Name: "BASE_IMAGE", Value: "mysql:8"},
-				{Name: "SCHEMA_URL", Value: "https://raw.githubusercontent.com/jOOQ/jOOQ/main/jOOQ-examples/Sakila/mysql-sakila-db/mysql-sakila-schema.sql"},
+				{Name: "SCHEMA_URL", Value: "https://raw.githubusercontent.com/jOOQ/sakila/main/mysql-sakila-db/mysql-sakila-schema.sql"},
 				{Name: "TARGET", Value: "/docker-entrypoint-initdb.d"},
 				{Name: "USER", Value: "root"},
 			},
@@ -96,7 +96,7 @@ var (
 		"sqlserver": {
 			BuildArgs: []dc.BuildArg{
 				{Name: "BASE_IMAGE", Value: "mcr.microsoft.com/mssql/server:2019-latest"},
-				{Name: "SCHEMA_URL", Value: "https://raw.githubusercontent.com/jOOQ/jOOQ/main/jOOQ-examples/Sakila/sql-server-sakila-db/sql-server-sakila-schema.sql"},
+				{Name: "SCHEMA_URL", Value: "https://raw.githubusercontent.com/jOOQ/sakila/main/sql-server-sakila-db/sql-server-sakila-schema.sql"},
 				{Name: "TARGET", Value: "/schema"},
 				{Name: "USER", Value: "mssql:0"},
 			},

--- a/drivers/sqlite3/sqshared/reader_test.go
+++ b/drivers/sqlite3/sqshared/reader_test.go
@@ -51,7 +51,7 @@ func createDb(location, name string) error {
 		return err
 	}
 	baseImage := "centos:7"
-	schemaURL := "https://raw.githubusercontent.com/jOOQ/jOOQ/main/jOOQ-examples/Sakila/sqlite-sakila-db/sqlite-sakila-schema.sql"
+	schemaURL := "https://raw.githubusercontent.com/jOOQ/sakila/main/sqlite-sakila-db/sqlite-sakila-schema.sql"
 	target := "/schema"
 	buildOptions := types.ImageBuildOptions{
 		Tags: []string{"usql-sqlite"},


### PR DESCRIPTION
Looks like we don't run these tests by default and forgot to update `Open()` calls in there to match 8fd96c3c6a71f02caf2efc6db0dbe39ce17a9c2c. I also improved making sure that the SQL Server container is ready before creating the schema.