### PR TITLE
Do not use pager when \watch

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -914,7 +914,7 @@ func (h *Handler) query(ctx context.Context, w io.Writer, opt metacmd.Option, ty
 			}
 			w = pipe
 		}
-	} else {
+	} else if opt.Exec != metacmd.ExecWatch {
 		params["pager_cmd"] = env.All()["PAGER"]
 	}
 	useColumnTypes := drivers.UseColumnTypes(h.u)


### PR DESCRIPTION
Users do not want the pager to start every time it is run with \watch.
Resolve #313 