### PR TITLE
allow to set EDITOR variable inside usql session, fixes #266

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -70,7 +70,7 @@ func OpenFile(u *user.User, path string, relative bool) (string, *os.File, error
 
 // EditFile edits a file. If path is empty, then a temporary file will be created.
 func EditFile(u *user.User, path, line, s string) ([]rune, error) {
-	ed := Getenv(text.CommandUpper()+"_EDITOR", "EDITOR", "VISUAL")
+	ed := All()["EDITOR"]
 	if ed == "" {
 		return nil, text.ErrNoEditorDefined
 	}

--- a/env/types.go
+++ b/env/types.go
@@ -59,10 +59,12 @@ func init() {
 	if pagerCmd != "" {
 		pager = "on"
 	}
+
 	vars = Vars{
 		// usql related logic
 		"SHOW_HOST_INFORMATION": enableHostInformation,
 		"PAGER":                 pagerCmd,
+		"EDITOR":                Getenv("USQL_EDITOR", "EDITOR", "VISUAL"),
 		// syntax highlighting variables
 		"SYNTAX_HL":             enableSyntaxHL,
 		"SYNTAX_HL_FORMAT":      colorLevel.ChromaFormatterName(),


### PR DESCRIPTION
this PR changes how `EditFile()` behaves. Instead of checking env vars each time, it will check if the variable is present in the `All()` output.

`EDITOR` variable is obtained from the env var if available during `init()`