### PR TITLE
Add /dp command to information_schema reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ Informational
   \di[S+] [PATTERN]                    list indexes
   \dm[S+] [PATTERN]                    list materialized views
   \dn[S+] [PATTERN]                    list schemas
+  \dp[S] [PATTERN]                     list table, view, and sequence access privileges
   \ds[S+] [PATTERN]                    list sequences
   \dt[S+] [PATTERN]                    list tables
   \dv[S+] [PATTERN]                    list views

--- a/drivers/metadata/informationschema/metadata_test.go
+++ b/drivers/metadata/informationschema/metadata_test.go
@@ -10,11 +10,13 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 
 	_ "github.com/denisenkom/go-mssqldb" // DRIVER: sqlserver
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/google/go-cmp/cmp"
 	dt "github.com/ory/dockertest/v3"
 	dc "github.com/ory/dockertest/v3/docker"
 	_ "github.com/trinodb/trino-go-client/trino"
@@ -91,8 +93,11 @@ var (
 					infos.FunctionColumnsNumericPrecRadix: "10",
 					infos.ConstraintIsDeferrable:          "''",
 					infos.ConstraintInitiallyDeferred:     "''",
+					infos.PrivilegesGrantor:               "''",
 				}),
 				infos.WithSystemSchemas([]string{"mysql", "performance_schema", "information_schema"}),
+				infos.WithUsagePrivileges(false),
+				infos.WithSequences(false),
 			},
 		},
 		"sqlserver": {
@@ -131,6 +136,8 @@ var (
 					"INFORMATION_SCHEMA",
 					"sys",
 				}),
+				infos.WithUsagePrivileges(false),
+				infos.WithSequences(false),
 			},
 		},
 		"trino": {
@@ -200,7 +207,10 @@ func TestMain(m *testing.M) {
 				log.Fatal("Could not start resource: ", err)
 			}
 		}
-
+		state := db.Resource.Container.State.Status
+		if state != "created" && state != "running" {
+			log.Fatalf("Unexpected container state for %s: %s", dbName, state)
+		}
 		url := db.URL
 		if db.ReadinessURL != "" {
 			url = db.ReadinessURL
@@ -588,6 +598,418 @@ func TestSequences(t *testing.T) {
 		actual := strings.Join(names, ", ")
 		if actual != expected[dbName] {
 			t.Errorf("Wrong %s sequence names, expected:\n  %v\ngot:\n  %v", dbName, expected[dbName], names)
+		}
+	}
+}
+
+func TestPrivilegeSummaries_NonExistent(t *testing.T) {
+	type test struct {
+		Name   string
+		Db     *Database
+		Schema string
+	}
+	tests := map[string]test{
+		"pgsql":     {Db: dbs["pgsql"], Schema: "public"},
+		"mysql":     {Db: dbs["mysql"], Schema: "sakila"},
+		"sqlserver": {Db: dbs["sqlserver"], Schema: "dbo"},
+	}
+
+	for testName, test := range tests {
+		if test.Db != nil {
+			t.Run(testName, func(t *testing.T) {
+				table := "privtest_table"
+
+				// Read privileges
+				r := infos.New(test.Db.Opts...)(test.Db.DB).(metadata.PrivilegeSummaryReader)
+				result, err := r.PrivilegeSummaries(metadata.Filter{Schema: test.Schema, Name: table})
+				if err != nil {
+					t.Fatalf("Could not read privileges: %v", err)
+				}
+
+				// Check result
+				if result.Len() != 0 {
+					t.Errorf("Wrong result count, expected:\n  %d, got:\n  %d", 0, result.Len())
+				}
+			})
+		}
+	}
+}
+
+func TestPrivilegeSummaries(t *testing.T) {
+	type test struct {
+		Db             *Database
+		Schema         string
+		User           string
+		Create         string
+		CreateUserStmt string
+		DropUserStmt   string
+		Grants         []string
+		WantTable      metadata.ObjectPrivileges
+		WantColumn     metadata.ColumnPrivileges
+	}
+	setDefaults := func(t test) test {
+		if t.User == "" {
+			t.User = "privtest_user"
+		}
+		if t.Create == "" {
+			t.Create = "TABLE"
+		}
+		if t.CreateUserStmt == "" {
+			t.CreateUserStmt = "CREATE USER %s"
+		}
+		if t.DropUserStmt == "" {
+			t.DropUserStmt = "DROP USER %s"
+		}
+		if t.Grants == nil {
+			t.Grants = []string{}
+		}
+		if t.WantTable == nil {
+			t.WantTable = metadata.ObjectPrivileges{}
+		}
+		if t.WantColumn == nil {
+			t.WantColumn = metadata.ColumnPrivileges{}
+		}
+		return t
+	}
+	postgresDefaultTable := func() metadata.ObjectPrivileges {
+		return metadata.ObjectPrivileges{
+			metadata.ObjectPrivilege{Grantee: "postgres", Grantor: "postgres", IsGrantable: true, PrivilegeType: "INSERT"},
+			metadata.ObjectPrivilege{Grantee: "postgres", Grantor: "postgres", IsGrantable: true, PrivilegeType: "SELECT"},
+			metadata.ObjectPrivilege{Grantee: "postgres", Grantor: "postgres", IsGrantable: true, PrivilegeType: "UPDATE"},
+			metadata.ObjectPrivilege{Grantee: "postgres", Grantor: "postgres", IsGrantable: true, PrivilegeType: "DELETE"},
+			metadata.ObjectPrivilege{Grantee: "postgres", Grantor: "postgres", IsGrantable: true, PrivilegeType: "TRUNCATE"},
+			metadata.ObjectPrivilege{Grantee: "postgres", Grantor: "postgres", IsGrantable: true, PrivilegeType: "REFERENCES"},
+			metadata.ObjectPrivilege{Grantee: "postgres", Grantor: "postgres", IsGrantable: true, PrivilegeType: "TRIGGER"},
+		}
+	}
+	postgresDefaultColumn := func(columns []string) metadata.ColumnPrivileges {
+		p := metadata.ColumnPrivileges{}
+		for _, col := range columns {
+			p = append(p,
+				metadata.ColumnPrivilege{Column: col, Grantee: "postgres", Grantor: "postgres", IsGrantable: true, PrivilegeType: "INSERT"},
+				metadata.ColumnPrivilege{Column: col, Grantee: "postgres", Grantor: "postgres", IsGrantable: true, PrivilegeType: "SELECT"},
+				metadata.ColumnPrivilege{Column: col, Grantee: "postgres", Grantor: "postgres", IsGrantable: true, PrivilegeType: "UPDATE"},
+				metadata.ColumnPrivilege{Column: col, Grantee: "postgres", Grantor: "postgres", IsGrantable: true, PrivilegeType: "REFERENCES"})
+		}
+		return p
+	}
+	tests := map[string]test{
+		"pgsql-no-grants": setDefaults(test{
+			Db:         dbs["pgsql"],
+			Schema:     "public",
+			Grants:     []string{},
+			WantTable:  postgresDefaultTable(),
+			WantColumn: postgresDefaultColumn([]string{"col1", "col2"}),
+		}),
+		"pgsql-sequence": setDefaults(test{
+			Db:     dbs["pgsql"],
+			Schema: "public",
+			Create: "SEQUENCE",
+			Grants: []string{"USAGE"},
+			WantTable: metadata.ObjectPrivileges{
+				metadata.ObjectPrivilege{Grantee: "privtest_user", Grantor: "postgres", IsGrantable: false, PrivilegeType: "USAGE"},
+				metadata.ObjectPrivilege{Grantee: "postgres", Grantor: "postgres", IsGrantable: true, PrivilegeType: "USAGE"},
+			},
+		}),
+		"pgsql-view": setDefaults(test{
+			Db:     dbs["pgsql"],
+			Schema: "public",
+			Create: "VIEW",
+			Grants: []string{"SELECT", "INSERT*"},
+			WantTable: append(postgresDefaultTable(),
+				metadata.ObjectPrivilege{Grantee: "privtest_user", Grantor: "postgres", IsGrantable: false, PrivilegeType: "SELECT"},
+				metadata.ObjectPrivilege{Grantee: "privtest_user", Grantor: "postgres", IsGrantable: true, PrivilegeType: "INSERT"},
+			),
+			WantColumn: append(
+				postgresDefaultColumn([]string{"col1", "col2"}),
+				metadata.ColumnPrivilege{Column: "col1", Grantee: "privtest_user", Grantor: "postgres", IsGrantable: false, PrivilegeType: "SELECT"},
+				metadata.ColumnPrivilege{Column: "col1", Grantee: "privtest_user", Grantor: "postgres", IsGrantable: true, PrivilegeType: "INSERT"},
+				metadata.ColumnPrivilege{Column: "col2", Grantee: "privtest_user", Grantor: "postgres", IsGrantable: false, PrivilegeType: "SELECT"},
+				metadata.ColumnPrivilege{Column: "col2", Grantee: "privtest_user", Grantor: "postgres", IsGrantable: true, PrivilegeType: "INSERT"},
+			),
+		}),
+		"pgsql-table": setDefaults(test{
+			Db:     dbs["pgsql"],
+			Schema: "public",
+			Grants: []string{"SELECT", "INSERT*"},
+			WantTable: append(postgresDefaultTable(),
+				metadata.ObjectPrivilege{Grantee: "privtest_user", Grantor: "postgres", IsGrantable: false, PrivilegeType: "SELECT"},
+				metadata.ObjectPrivilege{Grantee: "privtest_user", Grantor: "postgres", IsGrantable: true, PrivilegeType: "INSERT"},
+			),
+			WantColumn: append(
+				postgresDefaultColumn([]string{"col1", "col2"}),
+				metadata.ColumnPrivilege{Column: "col1", Grantee: "privtest_user", Grantor: "postgres", IsGrantable: false, PrivilegeType: "SELECT"},
+				metadata.ColumnPrivilege{Column: "col1", Grantee: "privtest_user", Grantor: "postgres", IsGrantable: true, PrivilegeType: "INSERT"},
+				metadata.ColumnPrivilege{Column: "col2", Grantee: "privtest_user", Grantor: "postgres", IsGrantable: false, PrivilegeType: "SELECT"},
+				metadata.ColumnPrivilege{Column: "col2", Grantee: "privtest_user", Grantor: "postgres", IsGrantable: true, PrivilegeType: "INSERT"},
+			),
+		}),
+		"pgsql-column": setDefaults(test{
+			Db:        dbs["pgsql"],
+			Schema:    "public",
+			Grants:    []string{"SELECT(col1)", "INSERT(col2)*"},
+			WantTable: postgresDefaultTable(),
+			WantColumn: append(
+				postgresDefaultColumn([]string{"col1", "col2"}),
+				metadata.ColumnPrivilege{Column: "col1", Grantee: "privtest_user", Grantor: "postgres", IsGrantable: false, PrivilegeType: "SELECT"},
+				metadata.ColumnPrivilege{Column: "col2", Grantee: "privtest_user", Grantor: "postgres", IsGrantable: true, PrivilegeType: "INSERT"},
+			),
+		}),
+		"pgsql-table-column": setDefaults(test{
+			Db:     dbs["pgsql"],
+			Schema: "public",
+			Grants: []string{"SELECT", "INSERT(col1)"},
+			WantTable: append(postgresDefaultTable(),
+				metadata.ObjectPrivilege{Grantee: "privtest_user", Grantor: "postgres", IsGrantable: false, PrivilegeType: "SELECT"},
+			),
+			WantColumn: append(
+				postgresDefaultColumn([]string{"col1", "col2"}),
+				metadata.ColumnPrivilege{Column: "col1", Grantee: "privtest_user", Grantor: "postgres", IsGrantable: false, PrivilegeType: "SELECT"},
+				metadata.ColumnPrivilege{Column: "col1", Grantee: "privtest_user", Grantor: "postgres", IsGrantable: false, PrivilegeType: "INSERT"},
+				metadata.ColumnPrivilege{Column: "col2", Grantee: "privtest_user", Grantor: "postgres", IsGrantable: false, PrivilegeType: "SELECT"},
+			),
+		}),
+		"mysql-no-grants": setDefaults(test{
+			Db:        dbs["mysql"],
+			Schema:    "sakila",
+			User:      "'privtest_user'@'%'",
+			Grants:    []string{},
+			WantTable: metadata.ObjectPrivileges{},
+		}),
+		"mysql-view": setDefaults(test{
+			Db:     dbs["mysql"],
+			Schema: "sakila",
+			Create: "VIEW",
+			User:   "'privtest_user'@'%'",
+			Grants: []string{"SELECT", "INSERT"},
+			WantTable: metadata.ObjectPrivileges{
+				metadata.ObjectPrivilege{Grantee: "'privtest_user'@'%'", Grantor: "", IsGrantable: false, PrivilegeType: "SELECT"},
+				metadata.ObjectPrivilege{Grantee: "'privtest_user'@'%'", Grantor: "", IsGrantable: false, PrivilegeType: "INSERT"},
+			},
+		}),
+		"mysql-view-grantable": setDefaults(test{
+			Db:     dbs["mysql"],
+			Schema: "sakila",
+			Create: "VIEW",
+			User:   "'privtest_user'@'%'",
+			Grants: []string{"SELECT*", "INSERT*"},
+			WantTable: metadata.ObjectPrivileges{
+				metadata.ObjectPrivilege{Grantee: "'privtest_user'@'%'", Grantor: "", IsGrantable: true, PrivilegeType: "SELECT"},
+				metadata.ObjectPrivilege{Grantee: "'privtest_user'@'%'", Grantor: "", IsGrantable: true, PrivilegeType: "INSERT"},
+			},
+		}),
+		"mysql-table": setDefaults(test{
+			Db:     dbs["mysql"],
+			Schema: "sakila",
+			User:   "'privtest_user'@'%'",
+			Grants: []string{"SELECT", "INSERT"},
+			WantTable: metadata.ObjectPrivileges{
+				metadata.ObjectPrivilege{Grantee: "'privtest_user'@'%'", Grantor: "", IsGrantable: false, PrivilegeType: "SELECT"},
+				metadata.ObjectPrivilege{Grantee: "'privtest_user'@'%'", Grantor: "", IsGrantable: false, PrivilegeType: "INSERT"},
+			},
+		}),
+		"mysql-table-grantable": setDefaults(test{
+			Db:     dbs["mysql"],
+			Schema: "sakila",
+			User:   "'privtest_user'@'%'",
+			Grants: []string{"SELECT*", "INSERT*"},
+			WantTable: metadata.ObjectPrivileges{
+				metadata.ObjectPrivilege{Grantee: "'privtest_user'@'%'", Grantor: "", IsGrantable: true, PrivilegeType: "SELECT"},
+				metadata.ObjectPrivilege{Grantee: "'privtest_user'@'%'", Grantor: "", IsGrantable: true, PrivilegeType: "INSERT"},
+			},
+		}),
+		"mysql-column": setDefaults(test{
+			Db:     dbs["mysql"],
+			Schema: "sakila",
+			User:   "'privtest_user'@'%'",
+			Grants: []string{"SELECT(col1)", "INSERT(col2)"},
+			WantColumn: metadata.ColumnPrivileges{
+				metadata.ColumnPrivilege{Column: "col1", Grantee: "'privtest_user'@'%'", Grantor: "", IsGrantable: false, PrivilegeType: "SELECT"},
+				metadata.ColumnPrivilege{Column: "col2", Grantee: "'privtest_user'@'%'", Grantor: "", IsGrantable: false, PrivilegeType: "INSERT"},
+			},
+		}),
+		"mysql-column-grantable": setDefaults(test{
+			Db:     dbs["mysql"],
+			Schema: "sakila",
+			User:   "'privtest_user'@'%'",
+			Grants: []string{"SELECT(col1)*", "INSERT(col2)*"},
+			WantColumn: metadata.ColumnPrivileges{
+				metadata.ColumnPrivilege{Column: "col1", Grantee: "'privtest_user'@'%'", Grantor: "", IsGrantable: true, PrivilegeType: "SELECT"},
+				metadata.ColumnPrivilege{Column: "col2", Grantee: "'privtest_user'@'%'", Grantor: "", IsGrantable: true, PrivilegeType: "INSERT"},
+			},
+		}),
+		"mysql-table-column": setDefaults(test{
+			Db:     dbs["mysql"],
+			Schema: "sakila",
+			User:   "'privtest_user'@'%'",
+			Grants: []string{"SELECT", "INSERT(col1)"},
+			WantTable: metadata.ObjectPrivileges{
+				metadata.ObjectPrivilege{Grantee: "'privtest_user'@'%'", Grantor: "", IsGrantable: false, PrivilegeType: "SELECT"},
+			},
+			WantColumn: metadata.ColumnPrivileges{
+				metadata.ColumnPrivilege{Column: "col1", Grantee: "'privtest_user'@'%'", Grantor: "", IsGrantable: false, PrivilegeType: "INSERT"},
+			},
+		}),
+		"sqlserver-no-grants": setDefaults(test{
+			Db:             dbs["sqlserver"],
+			Schema:         "dbo",
+			CreateUserStmt: "CREATE LOGIN %[1]s WITH PASSWORD = 'yourStrong123_Password'; CREATE USER %[1]s FOR LOGIN %[1]s",
+			DropUserStmt:   "DROP USER %[1]s; DROP LOGIN %[1]s",
+			Grants:         []string{},
+			WantTable:      metadata.ObjectPrivileges{},
+		}),
+		"sqlserver-view": setDefaults(test{
+			Db:             dbs["sqlserver"],
+			Schema:         "dbo",
+			Create:         "VIEW",
+			CreateUserStmt: "CREATE LOGIN %[1]s WITH PASSWORD = 'yourStrong123_Password'; CREATE USER %[1]s FOR LOGIN %[1]s",
+			DropUserStmt:   "DROP USER %[1]s; DROP LOGIN %[1]s",
+			Grants:         []string{"SELECT", "INSERT*"},
+			WantTable: metadata.ObjectPrivileges{
+				metadata.ObjectPrivilege{Grantee: "privtest_user", Grantor: "dbo", IsGrantable: false, PrivilegeType: "SELECT"},
+				metadata.ObjectPrivilege{Grantee: "privtest_user", Grantor: "dbo", IsGrantable: true, PrivilegeType: "INSERT"},
+			},
+		}),
+		"sqlserver-table": setDefaults(test{
+			Db:             dbs["sqlserver"],
+			Schema:         "dbo",
+			CreateUserStmt: "CREATE LOGIN %[1]s WITH PASSWORD = 'yourStrong123_Password'; CREATE USER %[1]s FOR LOGIN %[1]s",
+			DropUserStmt:   "DROP USER %[1]s; DROP LOGIN %[1]s",
+			Grants:         []string{"SELECT", "INSERT*"},
+			WantTable: metadata.ObjectPrivileges{
+				metadata.ObjectPrivilege{Grantee: "privtest_user", Grantor: "dbo", IsGrantable: false, PrivilegeType: "SELECT"},
+				metadata.ObjectPrivilege{Grantee: "privtest_user", Grantor: "dbo", IsGrantable: true, PrivilegeType: "INSERT"},
+			},
+		}),
+		"sqlserver-column": setDefaults(test{
+			Db:             dbs["sqlserver"],
+			Schema:         "dbo",
+			CreateUserStmt: "CREATE LOGIN %[1]s WITH PASSWORD = 'yourStrong123_Password'; CREATE USER %[1]s FOR LOGIN %[1]s",
+			DropUserStmt:   "DROP USER %[1]s; DROP LOGIN %[1]s",
+			Grants:         []string{"SELECT(col1)", "UPDATE(col2)*"},
+			WantColumn: metadata.ColumnPrivileges{
+				metadata.ColumnPrivilege{Column: "col1", Grantee: "privtest_user", Grantor: "dbo", IsGrantable: false, PrivilegeType: "SELECT"},
+				metadata.ColumnPrivilege{Column: "col2", Grantee: "privtest_user", Grantor: "dbo", IsGrantable: true, PrivilegeType: "UPDATE"},
+			},
+		}),
+		"sqlserver-table-column": setDefaults(test{
+			Db:             dbs["sqlserver"],
+			Schema:         "dbo",
+			CreateUserStmt: "CREATE LOGIN %[1]s WITH PASSWORD = 'yourStrong123_Password'; CREATE USER %[1]s FOR LOGIN %[1]s",
+			DropUserStmt:   "DROP USER %[1]s; DROP LOGIN %[1]s",
+			Grants:         []string{"SELECT", "UPDATE(col1)"},
+			WantTable: metadata.ObjectPrivileges{
+				metadata.ObjectPrivilege{Grantee: "privtest_user", Grantor: "dbo", IsGrantable: false, PrivilegeType: "SELECT"},
+			},
+			WantColumn: metadata.ColumnPrivileges{
+				metadata.ColumnPrivilege{Column: "col1", Grantee: "privtest_user", Grantor: "dbo", IsGrantable: false, PrivilegeType: "UPDATE"},
+			},
+		}),
+	}
+
+	for testName, test := range tests {
+		if test.Db != nil {
+			t.Run(testName, func(t *testing.T) {
+				// Create user, table and grants
+				const name = "privtest"
+				var query string
+				var err error
+				query = fmt.Sprintf(test.CreateUserStmt, test.User)
+				_, err = test.Db.DB.Exec(query)
+				if err != nil {
+					t.Fatalf("Could not CREATE USER:\n%s\n%s", query, err)
+				}
+				defer test.Db.DB.Exec(fmt.Sprintf(test.DropUserStmt, test.User))
+
+				switch test.Create {
+				case "TABLE":
+					query = fmt.Sprintf("CREATE TABLE %s.%s (col1 int, col2 varchar(255))", test.Schema, name)
+					_, err = test.Db.DB.Exec(query)
+					if err != nil {
+						t.Fatalf("Could not CREATE TABLE:\n%s\n%s", query, err)
+					}
+					defer test.Db.DB.Exec(fmt.Sprintf("DROP TABLE %s.%s", test.Schema, name))
+				case "VIEW":
+					query = fmt.Sprintf("CREATE TABLE %s.%s_table (col1 int, col2 varchar(255))", test.Schema, name)
+					_, err = test.Db.DB.Exec(query)
+					if err != nil {
+						t.Fatalf("Could not CREATE TABLE:\n%s\n%s", query, err)
+					}
+					defer test.Db.DB.Exec(fmt.Sprintf("DROP TABLE %s.%s_table", test.Schema, name))
+					query = fmt.Sprintf("CREATE VIEW %s.%s AS SELECT * FROM %[1]s.%[2]s_table", test.Schema, name)
+					_, err = test.Db.DB.Exec(query)
+					if err != nil {
+						t.Fatalf("Could not CREATE VIEW:\n%s\n%s", query, err)
+					}
+					defer test.Db.DB.Exec(fmt.Sprintf("DROP VIEW %s.%s", test.Schema, name))
+				case "SEQUENCE":
+					query = fmt.Sprintf("CREATE SEQUENCE %s.%s", test.Schema, name)
+					_, err = test.Db.DB.Exec(query)
+					if err != nil {
+						t.Fatalf("Could not CREATE SEQUENCE:\n%s\n%s", query, err)
+					}
+					defer test.Db.DB.Exec(fmt.Sprintf("DROP SEQUENCE %s.%s", test.Schema, name))
+				}
+
+				for _, grant := range test.Grants {
+					isGrantable := false
+					if grant[len(grant)-1] == '*' {
+						isGrantable = true
+						grant = grant[:len(grant)-1]
+					}
+					query = fmt.Sprintf("GRANT %s ON %s.%s TO %s", grant, test.Schema, name, test.User)
+					if isGrantable {
+						query += " WITH GRANT OPTION"
+					}
+					_, err = test.Db.DB.Exec(query)
+					if err != nil {
+						t.Fatalf("Could not GRANT %s:\n%s\n%s", grant, query, err)
+					}
+				}
+
+				// Read privileges
+				r := infos.New(test.Db.Opts...)(test.Db.DB).(metadata.PrivilegeSummaryReader)
+				types := []string{"TABLE", "BASE TABLE", "SYSTEM TABLE", "SYNONYM", "LOCAL TEMPORARY", "GLOBAL TEMPORARY", "VIEW", "SYSTEM VIEW", "MATERIALIZED VIEW", "SEQUENCE"}
+				result, err := r.PrivilegeSummaries(metadata.Filter{Schema: test.Schema, Name: name, Types: types})
+				if err != nil {
+					t.Fatalf("Could not read privileges: %v", err)
+				}
+
+				// Check result
+				if result.Len() != 1 {
+					t.Fatalf("Wrong result count\nWant:\t%d\nGot:\t%d\n", 1, result.Len())
+				}
+				result.Next()
+				if result.Get().Schema != test.Schema {
+					t.Errorf("Wrong schema!\nWant:\t%s\nGot:\t%s\n", test.Schema, result.Get().Schema)
+				}
+				if result.Get().Name != name {
+					t.Errorf("Wrong table!\nWant:\t%s\nGot:\t%s\n", name, result.Get().Name)
+				}
+				want := ""
+				switch test.Create {
+				case "TABLE":
+					want = "BASE TABLE"
+				default:
+					want = test.Create
+				}
+				if result.Get().ObjectType != want {
+					t.Errorf("Wrong Type!\nWant:\t%s\nGot:\t%s\n", want, result.Get().ObjectType)
+				}
+				gotTablePrivileges := result.Get().ObjectPrivileges
+				sort.Sort(gotTablePrivileges)
+				sort.Sort(test.WantTable)
+				if diff := cmp.Diff(test.WantTable, gotTablePrivileges); diff != "" {
+					t.Errorf("Wrong object privileges!\n(-expected, +got):\n%s", diff)
+				}
+
+				gotColumnPrivileges := result.Get().ColumnPrivileges
+				sort.Sort(gotColumnPrivileges)
+				sort.Sort(test.WantColumn)
+				if diff := cmp.Diff(test.WantColumn, gotColumnPrivileges); diff != "" {
+					t.Errorf("Wrong column privileges!\n(-expected, +got):\n%s", diff)
+				}
+			})
 		}
 	}
 }

--- a/drivers/metadata/metadata_test.go
+++ b/drivers/metadata/metadata_test.go
@@ -1,0 +1,175 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAccessPrivileges_String(t *testing.T) {
+	tests := []struct {
+		name string
+		ps   ObjectPrivileges
+		want string
+	}{
+		{
+			name: "multi",
+			ps: ObjectPrivileges{
+				{Grantee: "user1", Grantor: "user1", PrivilegeType: "INSERT", IsGrantable: true},
+				{Grantee: "user1", Grantor: "user1", PrivilegeType: "SELECT"},
+				{Grantee: "user2", Grantor: "user1", PrivilegeType: "INSERT"},
+				{Grantee: "user2", Grantor: "user1", PrivilegeType: "SELECT", IsGrantable: true},
+				{Grantee: "user3", Grantor: "user1", PrivilegeType: "SELECT", IsGrantable: true},
+				{Grantee: "user3", Grantor: "user2", PrivilegeType: "UPDATE"},
+			},
+			want: "user1=INSERT*,SELECT/user1\n" +
+				"user2=INSERT,SELECT*/user1\n" +
+				"user3=SELECT*/user1\n" +
+				"user3=UPDATE/user2",
+		},
+		{
+			name: "one",
+			ps: ObjectPrivileges{
+				{Grantee: "user1", Grantor: "user1", PrivilegeType: "INSERT"},
+			},
+			want: "user1=INSERT/user1",
+		},
+		{
+			name: "empty",
+			ps:   ObjectPrivileges{},
+			want: "",
+		},
+		{
+			name: "empty-grantor",
+			ps: ObjectPrivileges{
+				{Grantee: "user1", Grantor: "", PrivilegeType: "INSERT", IsGrantable: true},
+				{Grantee: "user1", Grantor: "", PrivilegeType: "SELECT"},
+				{Grantee: "user2", Grantor: "", PrivilegeType: "INSERT"},
+				{Grantee: "user2", Grantor: "", PrivilegeType: "SELECT", IsGrantable: true},
+				{Grantee: "user3", Grantor: "", PrivilegeType: "UPDATE"},
+			},
+			want: "user1=INSERT*,SELECT\n" +
+				"user2=INSERT,SELECT*\n" +
+				"user3=UPDATE",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.ps.String()
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Wrong AccessPrivileges.String(): (-expected, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestColumnPrivileges_String(t *testing.T) {
+	tests := []struct {
+		name string
+		ps   ColumnPrivileges
+		want string
+	}{
+		{
+			name: "multi",
+			ps: ColumnPrivileges{
+				{Column: "col1", Grantee: "user1", Grantor: "user1", PrivilegeType: "INSERT", IsGrantable: true},
+				{Column: "col1", Grantee: "user1", Grantor: "user1", PrivilegeType: "SELECT"},
+				{Column: "col1", Grantee: "user2", Grantor: "user1", PrivilegeType: "INSERT"},
+				{Column: "col1", Grantee: "user2", Grantor: "user1", PrivilegeType: "SELECT", IsGrantable: true},
+				{Column: "col1", Grantee: "user3", Grantor: "user1", PrivilegeType: "SELECT", IsGrantable: true},
+				{Column: "col1", Grantee: "user3", Grantor: "user2", PrivilegeType: "UPDATE"},
+				{Column: "col2", Grantee: "user1", Grantor: "user1", PrivilegeType: "INSERT", IsGrantable: true},
+				{Column: "col2", Grantee: "user1", Grantor: "user1", PrivilegeType: "SELECT"},
+				{Column: "col2", Grantee: "user2", Grantor: "user1", PrivilegeType: "INSERT"},
+				{Column: "col2", Grantee: "user2", Grantor: "user1", PrivilegeType: "SELECT", IsGrantable: true},
+				{Column: "col2", Grantee: "user3", Grantor: "user2", PrivilegeType: "UPDATE"},
+			},
+			want: "col1:\n" +
+				"  user1=INSERT*,SELECT/user1\n" +
+				"  user2=INSERT,SELECT*/user1\n" +
+				"  user3=SELECT*/user1\n" +
+				"  user3=UPDATE/user2\n" +
+				"col2:\n" +
+				"  user1=INSERT*,SELECT/user1\n" +
+				"  user2=INSERT,SELECT*/user1\n" +
+				"  user3=UPDATE/user2",
+		},
+		{
+			name: "one-multi",
+			ps: ColumnPrivileges{
+				{Column: "col2", Grantee: "user1", Grantor: "user1", PrivilegeType: "INSERT", IsGrantable: true},
+				{Column: "col3", Grantee: "user1", Grantor: "user1", PrivilegeType: "INSERT", IsGrantable: true},
+				{Column: "col3", Grantee: "user1", Grantor: "user1", PrivilegeType: "SELECT"},
+				{Column: "col3", Grantee: "user2", Grantor: "user1", PrivilegeType: "INSERT"},
+				{Column: "col3", Grantee: "user2", Grantor: "user1", PrivilegeType: "SELECT", IsGrantable: true},
+				{Column: "col3", Grantee: "user3", Grantor: "user2", PrivilegeType: "UPDATE"},
+			},
+			want: "col2:\n" +
+				"  user1=INSERT*/user1\n" +
+				"col3:\n" +
+				"  user1=INSERT*,SELECT/user1\n" +
+				"  user2=INSERT,SELECT*/user1\n" +
+				"  user3=UPDATE/user2",
+		},
+		{
+			name: "multi-one",
+			ps: ColumnPrivileges{
+				{Column: "col1", Grantee: "user1", Grantor: "user1", PrivilegeType: "INSERT", IsGrantable: true},
+				{Column: "col1", Grantee: "user1", Grantor: "user1", PrivilegeType: "SELECT"},
+				{Column: "col1", Grantee: "user2", Grantor: "user1", PrivilegeType: "INSERT"},
+				{Column: "col1", Grantee: "user2", Grantor: "user1", PrivilegeType: "SELECT", IsGrantable: true},
+				{Column: "col1", Grantee: "user3", Grantor: "user2", PrivilegeType: "UPDATE"},
+				{Column: "col2", Grantee: "user1", Grantor: "user1", PrivilegeType: "INSERT", IsGrantable: true},
+			},
+			want: "col1:\n" +
+				"  user1=INSERT*,SELECT/user1\n" +
+				"  user2=INSERT,SELECT*/user1\n" +
+				"  user3=UPDATE/user2\n" +
+				"col2:\n" +
+				"  user1=INSERT*/user1",
+		},
+		{
+			name: "one",
+			ps: ColumnPrivileges{
+				{Column: "col1", Grantee: "user1", Grantor: "user1", PrivilegeType: "INSERT"},
+			},
+			want: "col1:\n  user1=INSERT/user1",
+		},
+		{
+			name: "empty",
+			ps:   ColumnPrivileges{},
+			want: "",
+		},
+		{
+			name: "empty-grantor",
+			ps: ColumnPrivileges{
+				{Column: "col1", Grantee: "user1", Grantor: "", PrivilegeType: "INSERT", IsGrantable: true},
+				{Column: "col1", Grantee: "user1", Grantor: "", PrivilegeType: "SELECT"},
+				{Column: "col1", Grantee: "user2", Grantor: "", PrivilegeType: "INSERT"},
+				{Column: "col1", Grantee: "user2", Grantor: "", PrivilegeType: "SELECT", IsGrantable: true},
+				{Column: "col1", Grantee: "user3", Grantor: "", PrivilegeType: "UPDATE"},
+				{Column: "col2", Grantee: "user1", Grantor: "", PrivilegeType: "INSERT", IsGrantable: true},
+				{Column: "col2", Grantee: "user1", Grantor: "", PrivilegeType: "SELECT"},
+				{Column: "col2", Grantee: "user2", Grantor: "", PrivilegeType: "INSERT"},
+				{Column: "col2", Grantee: "user2", Grantor: "", PrivilegeType: "SELECT", IsGrantable: true},
+				{Column: "col2", Grantee: "user3", Grantor: "", PrivilegeType: "UPDATE"},
+			},
+			want: "col1:\n" +
+				"  user1=INSERT*,SELECT\n" +
+				"  user2=INSERT,SELECT*\n" +
+				"  user3=UPDATE\n" +
+				"col2:\n" +
+				"  user1=INSERT*,SELECT\n" +
+				"  user2=INSERT,SELECT*\n" +
+				"  user3=UPDATE",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.ps.String()
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Wrong ColumnPrivileges.String(): (-expected, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/drivers/metadata/mysql/metadata.go
+++ b/drivers/metadata/mysql/metadata.go
@@ -22,10 +22,12 @@ var (
 			infos.FunctionColumnsNumericPrecRadix: "10",
 			infos.ConstraintIsDeferrable:          "''",
 			infos.ConstraintInitiallyDeferred:     "''",
+			infos.PrivilegesGrantor:               "''",
 			infos.ConstraintJoinCond:              "AND r.table_name = f.table_name",
 		}),
 		infos.WithSystemSchemas([]string{"mysql", "information_schema", "performance_schema", "sys"}),
 		infos.WithCurrentSchema("COALESCE(DATABASE(), '%')"),
+		infos.WithUsagePrivileges(false),
 	)
 	// NewCompleter for MySQL databases
 	NewCompleter = func(db drivers.DB, opts ...completer.Option) readline.AutoCompleter {

--- a/drivers/metadata/postgres/metadata.go
+++ b/drivers/metadata/postgres/metadata.go
@@ -144,7 +144,7 @@ FROM pg_catalog.pg_class c
 		}
 		conds = append(conds, fmt.Sprintf("c.relkind IN (%s)", strings.Join(pholders, ", ")))
 	}
-	rows, closeRows, err := r.query(qstr, conds, "1, 2", vals...)
+	rows, closeRows, err := r.query(qstr, conds, "1, 3, 2", vals...)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return metadata.NewTableSet([]metadata.Table{}), nil

--- a/drivers/metadata/reader.go
+++ b/drivers/metadata/reader.go
@@ -10,19 +10,20 @@ import (
 
 // PluginReader allows to be easily composed from other readers
 type PluginReader struct {
-	catalogs          func(Filter) (*CatalogSet, error)
-	schemas           func(Filter) (*SchemaSet, error)
-	tables            func(Filter) (*TableSet, error)
-	columns           func(Filter) (*ColumnSet, error)
-	columnStats       func(Filter) (*ColumnStatSet, error)
-	indexes           func(Filter) (*IndexSet, error)
-	indexColumns      func(Filter) (*IndexColumnSet, error)
-	triggers          func(Filter) (*TriggerSet, error)
-	constraints       func(Filter) (*ConstraintSet, error)
-	constraintColumns func(Filter) (*ConstraintColumnSet, error)
-	functions         func(Filter) (*FunctionSet, error)
-	functionColumns   func(Filter) (*FunctionColumnSet, error)
-	sequences         func(Filter) (*SequenceSet, error)
+	catalogs           func(Filter) (*CatalogSet, error)
+	schemas            func(Filter) (*SchemaSet, error)
+	tables             func(Filter) (*TableSet, error)
+	columns            func(Filter) (*ColumnSet, error)
+	columnStats        func(Filter) (*ColumnStatSet, error)
+	indexes            func(Filter) (*IndexSet, error)
+	indexColumns       func(Filter) (*IndexColumnSet, error)
+	triggers           func(Filter) (*TriggerSet, error)
+	constraints        func(Filter) (*ConstraintSet, error)
+	constraintColumns  func(Filter) (*ConstraintColumnSet, error)
+	functions          func(Filter) (*FunctionSet, error)
+	functionColumns    func(Filter) (*FunctionColumnSet, error)
+	sequences          func(Filter) (*SequenceSet, error)
+	privilegeSummaries func(Filter) (*PrivilegeSummarySet, error)
 }
 
 var _ ExtendedReader = &PluginReader{}
@@ -69,6 +70,9 @@ func NewPluginReader(readers ...Reader) Reader {
 		}
 		if r, ok := i.(SequenceReader); ok {
 			p.sequences = r.Sequences
+		}
+		if r, ok := i.(PrivilegeSummaryReader); ok {
+			p.privilegeSummaries = r.PrivilegeSummaries
 		}
 	}
 	return &p
@@ -163,6 +167,13 @@ func (p PluginReader) Sequences(f Filter) (*SequenceSet, error) {
 		return nil, text.ErrNotSupported
 	}
 	return p.sequences(f)
+}
+
+func (p PluginReader) PrivilegeSummaries(f Filter) (*PrivilegeSummarySet, error) {
+	if p.privilegeSummaries == nil {
+		return nil, text.ErrNotSupported
+	}
+	return p.privilegeSummaries(f)
 }
 
 type LoggingReader struct {

--- a/drivers/snowflake/snowflake.go
+++ b/drivers/snowflake/snowflake.go
@@ -31,6 +31,7 @@ func init() {
 		infos.WithFunctions(false),
 		infos.WithIndexes(false),
 		infos.WithConstraints(false),
+		infos.WithColumnPrivileges(false),
 	)
 	drivers.Register("snowflake", drivers.Driver{
 		Err: func(err error) (string, string) {

--- a/drivers/sqlserver/reader.go
+++ b/drivers/sqlserver/reader.go
@@ -43,6 +43,7 @@ func NewReader(db drivers.DB, opts ...metadata.ReaderOption) metadata.Reader {
 		}),
 		infos.WithCurrentSchema("schema_name()"),
 		infos.WithDataTypeFormatter(dataTypeFormatter),
+		infos.WithUsagePrivileges(false),
 	)(db, opts...)
 	mr := &metaReader{
 		LoggingReader: metadata.NewLoggingReader(db, opts...),

--- a/drivers/trino/trino.go
+++ b/drivers/trino/trino.go
@@ -29,6 +29,8 @@ func init() {
 			infos.WithSequences(false),
 			infos.WithIndexes(false),
 			infos.WithConstraints(false),
+			infos.WithColumnPrivileges(false),
+			infos.WithUsagePrivileges(false),
 		)(db, opts...)
 		mr := &metaReader{
 			LoggingReader: metadata.NewLoggingReader(db, opts...),

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/gocql/gocql v1.2.0
 	github.com/godror/godror v0.30.2
 	github.com/gohxs/readline v0.0.0-20171011095936-a780388e6e7c
+	github.com/google/go-cmp v0.5.8
 	github.com/google/goexpect v0.0.0-20210430020637-ab937bf7fd6f
 	github.com/jackc/pgconn v1.13.0
 	github.com/jackc/pgx/v4 v4.17.0
@@ -146,7 +147,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/flatbuffers v2.0.6+incompatible // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.0 // indirect

--- a/metacmd/cmds.go
+++ b/metacmd/cmds.go
@@ -733,6 +733,7 @@ func init() {
 				"dn[S+]": {"list schemas", "[PATTERN]"},
 				"dt[S+]": {"list tables", "[PATTERN]"},
 				"di[S+]": {"list indexes", "[PATTERN]"},
+				"dp[S]":  {"list table, view, and sequence access privileges", "[PATTERN]"},
 				"l[+]":   {"list databases", ""},
 			},
 			Process: func(p *Params) error {
@@ -765,6 +766,8 @@ func init() {
 					return m.ListIndexes(p.Handler.URL(), pattern, verbose, showSystem)
 				case "l":
 					return m.ListAllDbs(p.Handler.URL(), pattern, verbose)
+				case "dp":
+					return m.ListPrivilegeSummaries(p.Handler.URL(), pattern, showSystem)
 				}
 				return nil
 			},


### PR DESCRIPTION
Adds the /dp backslash command. It lists privileges that have been granted on tables, views and sequences.

It is implemented in the information schema metadata reader and was tested against postgres, sqlserver and mariadb. I could not test it against snowflake and netezza, since I don't have access to a development instance.

Partly implements #172