### PR TITLE
Adding TABLE pg command to query map.

### DIFF
--- a/drivers/qtype.go
+++ b/drivers/qtype.go
@@ -18,6 +18,7 @@ var queryMap = map[string]bool{
 	"VALUES":     true, // compute a set of rows
 	"LIST":       true, // list permissions, roles, users (cassandra)
 	"EXEC":       true, // execute a stored procedure that returns rows (not postgres)
+	"TABLE":      true, // shortcut for select * from <table> (postgresql)
 }
 
 // execMap is the map of SQL prefixes to execute.


### PR DESCRIPTION
Fix for issue #366. Add a TABLE command(shortcut for `SELECT * FROM <name>`) to queryMap. This will make `Handler` to use `query` instead of `exec`.