### PR TITLE
Adding TABLE command to completer.

### DIFF
--- a/drivers/completer/completer.go
+++ b/drivers/completer/completer.go
@@ -435,6 +435,10 @@ func (c completer) complete(previousWords []string, text []rune) [][]rune {
 	if TailMatches(IGNORE_CASE, previousWords, "FROM|JOIN") {
 		return c.completeWithSelectables(text)
 	}
+	/* TABLE, but not TABLE embedded in other commands */
+	if matches(IGNORE_CASE, previousWords, "TABLE") {
+		return c.completeWithUpdatables(text)
+	}
 	/* Backslash commands */
 	if TailMatches(MATCH_CASE, previousWords, `\cd|\e|\edit|\g|\gx|\i|\include|\ir|\include_relative|\o|\out|\s|\w|\write`) {
 		return completeFromFiles(text)

--- a/drivers/completer/completer_test.go
+++ b/drivers/completer/completer_test.go
@@ -243,6 +243,50 @@ func TestCompleter(t *testing.T) {
 			},
 			0,
 		},
+		{
+			"TABLE Selectables",
+			"TABLE ",
+			6,
+			[]string{
+				"main",
+				"remote",
+				"default",
+				"system",
+				"film",
+				"factory",
+			},
+			0,
+		},
+		{
+			"TABLE namespaced with catalog",
+			"TABLE remote.",
+			13,
+			[]string{
+				"film",
+				"factory",
+			},
+			7,
+		},
+		{
+			"TABLE namespaced with schema",
+			"TABLE system.",
+			13,
+			[]string{
+				"film",
+				"factory",
+			},
+			7,
+		},
+		{
+			"TABLE namespaced with catalog.schema",
+			"TABLE remote.default.f",
+			22,
+			[]string{
+				"ilm",
+				"actory",
+			},
+			16,
+		},
 	}
 
 	completer := NewDefaultCompleter(WithReader(mockReader{}), WithConnStrings([]string{"pg://"}))


### PR DESCRIPTION
Fix for #372. Adding missing TABLE command to completer. These changes fix the lack of `TAB` auto-completion.