### PR TITLE
Use scan types reported by driver when scanning values for copy

### DIFF
--- a/drivers/csvq/csvq.go
+++ b/drivers/csvq/csvq.go
@@ -33,5 +33,6 @@ func init() {
 			}
 			return "CSVQ " + ver, nil
 		},
+		Copy: drivers.CopyWithInsert(func(int) string { return "?" }),
 	})
 }


### PR DESCRIPTION
This should be more correct than relying on a driver to properly handle an empty interface. I checked how the type is used in `go/1.19.1/libexec/src/database/sql/sql_test.go`.