### PR TITLE
Implement help subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,6 +720,8 @@ always appreciated][contributing]!
 
 #### Variables and Interpolation
 
+To see the list of specially treated variables, run the `\? variables` command.
+
 `usql` supports client-side interpolation of variables that can be `\set` and
 `\unset`:
 

--- a/drivers/completer/completer.go
+++ b/drivers/completer/completer.go
@@ -509,6 +509,9 @@ func (c completer) complete(previousWords []string, text []rune) [][]rune {
 		TailMatches(MATCH_CASE, previousWords, `\pset`, `*`, `*`) {
 		return nil
 	}
+	if TailMatches(MATCH_CASE, previousWords, `\?`) {
+		return CompleteFromList(text, "commands", "options", "variables")
+	}
 	// is suggesting basic sql commands better than nothing?
 	return CompleteFromList(text, c.sqlCommands...)
 }

--- a/metacmd/cmds.go
+++ b/metacmd/cmds.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/xo/dburl"
 	"github.com/xo/usql/drivers"
 	"github.com/xo/usql/env"
@@ -49,7 +50,21 @@ func init() {
 				"? ": {"show help on special variables", "variables"},
 			},
 			Process: func(p *Params) error {
-				Listing(p.Handler.IO().Stdout())
+				name, err := p.Get(false)
+				if err != nil {
+					return err
+				}
+				switch name {
+				default:
+					Listing(p.Handler.IO().Stdout())
+				case "commands":
+					Listing(p.Handler.IO().Stdout())
+				case "options":
+					// FIXME: decouple
+					kingpin.Usage()
+				case "variables":
+					env.Listing(p.Handler.IO().Stdout())
+				}
 				return nil
 			},
 		},


### PR DESCRIPTION
The `\?` command already printed help for all available commands, but it also should support subcommands for options and variables. This PR implements them and adds autocomplete.

Things to look at:
* Options are always printed to stdout, ignoring the handler's settings.
* All variable names and descriptions are kept in lists but converted to a string, it might as well be just one big string. I did **not** attempt to refactor the code so they're all defined in a single place.
* I did **not** attempt to address #379 since the README is big enough already and variables are also already referenced in a few places. I'm not convinced copying the output of `\? variables` there would help.

Resolves #384 and partially resolves #258 

BTW I noticed the release plugin gathers release notes from PRs so I'll try to avoid committing important changes directly to the default branch.