### PR TITLE
snowflake: enable multi-line comments

### DIFF
--- a/drivers/snowflake/snowflake.go
+++ b/drivers/snowflake/snowflake.go
@@ -33,6 +33,7 @@ func init() {
 		infos.WithColumnPrivileges(false),
 	)
 	drivers.Register("snowflake", drivers.Driver{
+		AllowMultilineComments: true,
 		Err: func(err error) (string, string) {
 			if e, ok := err.(*gosnowflake.SnowflakeError); ok {
 				return strconv.Itoa(e.Number), e.Message


### PR DESCRIPTION
Snowflake supports `/* */` comments, so lets enable them on the usql driver side.

<img width="686" alt="Screenshot 2023-03-14 at 10 40 27 PM" src="https://user-images.githubusercontent.com/64023893/225217430-1aa4cd04-9638-431f-a019-9a81c5da4abe.png">
