### PR TITLE
Fix FlightSQL driver

### DIFF
--- a/drivers/flightsql/flightsql.go
+++ b/drivers/flightsql/flightsql.go
@@ -4,25 +4,10 @@
 package flightsql
 
 import (
-	"context"
-
 	_ "github.com/apache/arrow/go/v12/arrow/flight/flightsql/driver" // DRIVER
 	"github.com/xo/usql/drivers"
 )
 
 func init() {
-	drivers.Register("flightsql", drivers.Driver{
-		AllowMultilineComments: true,
-		Version: func(ctx context.Context, db drivers.DB) (string, error) {
-			var ver string
-			err := db.QueryRowContext(
-				ctx,
-				`SELECT version()`,
-			).Scan(&ver)
-			if err != nil {
-				return "", err
-			}
-			return "FlightSQL " + ver, nil
-		},
-	})
+	drivers.Register("flightsql", drivers.Driver{})
 }


### PR DESCRIPTION
Not all FlightSQL backends support `SELECT version()` so we should not make any assumptions. The same holds for comment support. This PR registers an empty driver to prevent errors when connecting.