### PR TITLE
Add support for custom tls config in Vertica driver

### DIFF
--- a/drivers/vertica/vertica.go
+++ b/drivers/vertica/vertica.go
@@ -5,16 +5,65 @@ package vertica
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"database/sql"
+	"fmt"
+	"io"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
 
-	_ "github.com/vertica/vertica-sql-go" // DRIVER
+	vertigo "github.com/vertica/vertica-sql-go" // DRIVER
 	"github.com/vertica/vertica-sql-go/logger"
+	"github.com/xo/dburl"
 	"github.com/xo/usql/drivers"
 )
 
 func init() {
+	// List of custom TLS configurations that may be applied via query in connection string.
+	customTlsConfig := map[string]func(string, *tls.Config) error{
+		"ca_path": func(queryValue string, c *tls.Config) error {
+			rootCertPool := x509.NewCertPool()
+
+			pem, err := os.ReadFile(queryValue)
+			if err != nil {
+				return err
+			}
+
+			if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
+				return fmt.Errorf("error: failed to append pem to cert pool")
+			}
+
+			c.RootCAs = rootCertPool
+
+			return nil
+		},
+	}
+
+	hasCustomTlsConfig := func(queries url.Values) bool {
+		for key := range customTlsConfig {
+			if queries.Has(key) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	applyCustomTlsConfig := func(queries url.Values, tlsConfig *tls.Config) error {
+		for key, configFunction := range customTlsConfig {
+			if queries.Has(key) {
+				if err := configFunction(queries.Get(key), tlsConfig); err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	}
+
 	// turn off logging
 	if os.Getenv("VERTICA_SQL_GO_LOG_LEVEL") == "" {
 		logger.SetLogLevel(logger.NONE)
@@ -29,6 +78,45 @@ func init() {
 				return "", err
 			}
 			return ver, nil
+		},
+		Open: func(_ context.Context, u *dburl.URL, stdout, stderr func() io.Writer) (func(string, string) (*sql.DB, error), error) {
+			return func(_, _ string) (*sql.DB, error) {
+				queries := u.Query()
+
+				if hasCustomTlsConfig(queries) {
+					if queries.Get("tlsmode") != "server-strict" {
+						configNames := []string{}
+
+						for key := range customTlsConfig {
+							configNames = append(configNames, key)
+						}
+
+						return nil, fmt.Errorf(fmt.Sprintf("error: when custom tls configurations are set (%s), tlsmode must be set to server-strict", strings.Join(configNames, ",")))
+					}
+
+					tlsConfig := &tls.Config{ServerName: u.Hostname()}
+
+					if err := applyCustomTlsConfig(queries, tlsConfig); err != nil {
+						return nil, err
+					}
+
+					if err := vertigo.RegisterTLSConfig("custom_tls_config", tlsConfig); err != nil {
+						return nil, err
+					}
+
+					queries.Set("tlsmode", "custom_tls_config")
+				}
+
+				dsn := url.URL{
+					Scheme:   u.Driver,
+					User:     u.User,
+					Host:     u.Host,
+					Path:     u.Path,
+					RawQuery: queries.Encode(),
+				}
+
+				return sql.Open(u.Driver, dsn.String())
+			}, nil
 		},
 		ChangePassword: func(db drivers.DB, user, newpw, _ string) error {
 			_, err := db.Exec(`ALTER USER ` + user + ` IDENTIFIED BY '` + newpw + `'`)


### PR DESCRIPTION
Vertica driver supports [custom TLS configuration](https://github.com/vertica/vertica-sql-go#using-custom-tls-config), but the path to the custom CA needs to be passed somehow. I was considering adding it as a variable or as a connection string query. Finally, I found that passing it in queries was sufficient for me. This approach has worked for me, so I have decided to create a pull request and share my small changes.

Let me know how you feel about it. I am open to discussion and ready to make adjustments to ensure that these changes align with your requirements.

With this change, an example connection string with path to custom CA would look like this - vertica://user:password@host:port/database?tlsmode=/path/to/ca

12.06.2023:
- with those changes, secure connection with custom TLS config can be established via `vertica://<user>:<password>@<host>:<port>/<database>?tlsmode=server-strict&ca_path=/path/to/ca`, where `ca_path` is one of custom config. The solution allows to support more of [TLS options](https://pkg.go.dev/crypto/tls#Config) in the connection's string query if added to `customTlsConfig` map. 