### PR TITLE
Fixes in \copy implementation for Clickhouse

### DIFF
--- a/drivers/clickhouse/clickhouse.go
+++ b/drivers/clickhouse/clickhouse.go
@@ -5,7 +5,10 @@
 package clickhouse
 
 import (
+	"context"
 	"database/sql"
+	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -35,7 +38,82 @@ func init() {
 			}
 			return false
 		},
-		Copy:              drivers.CopyWithInsert(func(int) string { return "?" }),
+		Copy:              CopyWithInsert,
 		NewMetadataReader: NewMetadataReader,
 	})
+}
+
+// CopyWithInsert builds a copy handler based on insert.
+func CopyWithInsert(ctx context.Context, db *sql.DB, rows *sql.Rows, table string) (int64, error) {
+	columns, err := rows.Columns()
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch source rows columns: %w", err)
+	}
+	clen := len(columns)
+	query := table
+	if !strings.HasPrefix(strings.ToLower(query), "insert into") {
+		leftParen := strings.IndexRune(table, '(')
+		if leftParen == -1 {
+			colRows, err := db.QueryContext(ctx, "SELECT * FROM "+table+" WHERE 1=0")
+			if err != nil {
+				return 0, fmt.Errorf("failed to execute query to determine target table columns: %w", err)
+			}
+			columns, err := colRows.Columns()
+			_ = colRows.Close()
+			if err != nil {
+				return 0, fmt.Errorf("failed to fetch target table columns: %w", err)
+			}
+			table += "(" + strings.Join(columns, ", ") + ")"
+		}
+		// TODO if the db supports multiple rows per insert, create batches of 10 rows
+		query = "INSERT INTO " + table + " VALUES (" + strings.Repeat("?, ", clen-1) + "?)"
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	stmt, err := tx.PrepareContext(ctx, query)
+	if err != nil {
+		return 0, fmt.Errorf("failed to prepare insert query: %w", err)
+	}
+	defer stmt.Close()
+	columnTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch source column types: %w", err)
+	}
+	values := make([]interface{}, clen)
+	valueRefs := make([]reflect.Value, clen)
+	actuals := make([]interface{}, clen)
+	for i := 0; i < len(columnTypes); i++ {
+		valueRefs[i] = reflect.New(columnTypes[i].ScanType())
+		values[i] = valueRefs[i].Interface()
+	}
+	var n int64
+	for rows.Next() {
+		err = rows.Scan(values...)
+		if err != nil {
+			return n, fmt.Errorf("failed to scan row: %w", err)
+		}
+		//We can't use values... in Exec() below, because, in some cases, clickhouse
+		//driver doesn't accept pointer to an argument instead of the arg itself.
+		for i := range values {
+			actuals[i] = valueRefs[i].Elem().Interface()
+		}
+		res, err := stmt.ExecContext(ctx, actuals...)
+		if err != nil {
+			return n, fmt.Errorf("failed to exec insert: %w", err)
+		}
+		rn, err := res.RowsAffected()
+		if err != nil {
+			return n, fmt.Errorf("failed to check rows affected: %w", err)
+		}
+		n += rn
+	}
+	// TODO if using batches, flush the last batch,
+	// TODO prepare another statement and count remaining rows
+	err = tx.Commit()
+	if err != nil {
+		return n, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	return n, rows.Err()
 }

--- a/drivers/clickhouse/clickhouse.go
+++ b/drivers/clickhouse/clickhouse.go
@@ -65,7 +65,6 @@ func CopyWithInsert(ctx context.Context, db *sql.DB, rows *sql.Rows, table strin
 			}
 			table += "(" + strings.Join(columns, ", ") + ")"
 		}
-		// TODO if the db supports multiple rows per insert, create batches of 10 rows
 		query = "INSERT INTO " + table + " VALUES (" + strings.Repeat("?, ", clen-1) + "?)"
 	}
 	tx, err := db.BeginTx(ctx, nil)
@@ -109,8 +108,6 @@ func CopyWithInsert(ctx context.Context, db *sql.DB, rows *sql.Rows, table strin
 		}
 		n += rn
 	}
-	// TODO if using batches, flush the last batch,
-	// TODO prepare another statement and count remaining rows
 	err = tx.Commit()
 	if err != nil {
 		return n, fmt.Errorf("failed to commit transaction: %w", err)

--- a/drivers/clickhouse/testdata/clickhouse.sql
+++ b/drivers/clickhouse/testdata/clickhouse.sql
@@ -340,3 +340,11 @@ CREATE TABLE tutorial_unexpected.hits_v1 (
 )
 ENGINE = MergeTree()
 ORDER BY (Unexpected);
+
+CREATE DATABASE copy_test;
+CREATE TABLE copy_test.dest (
+    StringCol String,
+    NumCol UInt32
+)
+ENGINE = MergeTree()
+ORDER BY (StringCol);


### PR DESCRIPTION
A couple of fixes in the Copy function for Clickhouse:

- Don't prepare the SELECT statement that determines columns for the destination table as the Clickhouse driver omly supports preparing INSERT statements
- De-reference the pointers populated by Scan before supplying them to arguments of Exec because Clickhouse, in some cases, doesn't accept a pointer to an arguments, instead of the argument itself. For example, this happens when source database driver doesn't support ScanType() and the value populated by Scan is interface{}.

The new automated test fails without the fixes and succeeds with them.