### PR TITLE
#321: postgres and pgx support schema name in \copy

### DIFF
--- a/drivers/drivers_test.go
+++ b/drivers/drivers_test.go
@@ -423,6 +423,15 @@ func TestCopy(t *testing.T) {
 			dest: "staff_copy",
 		},
 		{
+			dbName: "pgsql",
+			setupQueries: []setupQuery{
+				{query: "DROP TABLE staff_copy"},
+				{query: "CREATE TABLE staff_copy AS SELECT * FROM staff WHERE 0=1", check: true},
+			},
+			src:  "select * from staff",
+			dest: "public.staff_copy",
+		},
+		{
 			dbName: "pgx",
 			setupQueries: []setupQuery{
 				{query: "DROP TABLE staff_copy"},
@@ -430,6 +439,15 @@ func TestCopy(t *testing.T) {
 			},
 			src:  "select * from staff",
 			dest: "staff_copy",
+		},
+		{
+			dbName: "pgx",
+			setupQueries: []setupQuery{
+				{query: "DROP TABLE staff_copy"},
+				{query: "CREATE TABLE staff_copy AS SELECT * FROM staff WHERE 0=1", check: true},
+			},
+			src:  "select * from staff",
+			dest: "public.staff_copy",
 		},
 		{
 			dbName: "mysql",

--- a/drivers/pgx/pgx.go
+++ b/drivers/pgx/pgx.go
@@ -122,7 +122,7 @@ func init() {
 			var n int64
 			err = conn.Raw(func(driverConn interface{}) error {
 				conn := driverConn.(*stdlib.Conn).Conn()
-				n, err = conn.CopyFrom(ctx, pgx.Identifier{table}, columns, crows)
+				n, err = conn.CopyFrom(ctx, pgx.Identifier(strings.SplitN(table, ".", 2)), columns, crows)
 				return err
 			})
 			return n, err
@@ -141,7 +141,11 @@ func (r *copyRows) Next() bool {
 
 func (r *copyRows) Values() ([]interface{}, error) {
 	err := r.rows.Scan(r.values...)
-	return r.values, err
+	actuals := make([]interface{}, len(r.values))
+	for i, v := range r.values {
+		actuals[i] = *(v.(*interface{}))
+	}
+	return actuals, err
 }
 
 func (r *copyRows) Err() error {

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -137,7 +137,11 @@ func init() {
 				if err != nil {
 					return 0, fmt.Errorf("failed to fetch target table columns: %w", err)
 				}
-				query = pq.CopyIn(table, columns...)
+				if schemaSep := strings.Index(table, "."); schemaSep >= 0 {
+					query = pq.CopyInSchema(table[:schemaSep], table[schemaSep+1:], columns...)
+				} else {
+					query = pq.CopyIn(table, columns...)
+				}
 			}
 			tx, err := db.BeginTx(ctx, nil)
 			if err != nil {


### PR DESCRIPTION
Closes #321 

Adds support postgres and pgx support schema name in table destination in \copy.
TestCopy in drivers_test is extended with cases with schema names.
`go test -v -tags pgx . -dbs=pgsql,pgx -test.run=TestCopy` after the fix. The new test cases
failed without the fix. 

Even the existing test case for pgx failed for me with this output:
```
$ go test -v -tags pgx . -dbs=pgsql,pgx -test.run=TestCopy
=== RUN   TestCopy
2024/04/28 20:10:49 Could not copy: ERROR: COPY from stdin failed: unable to encode (*interface {})(0xc0002b4120) into binary format for int4 (OID 23): cannot find encode plan (SQLSTATE 57014)
FAIL    github.com/xo/usql/drivers      0.048s
FAIL
```

I added code to dereference the pointers populated by Scan before passing them to pgx.Copy
to resolve that issue.
