### PR TITLE
fix: upload test output even on failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
         ls -alh output.log
     - name: Archive output
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: output
         path: output.log


### PR DESCRIPTION
It seems the "Archive output" step in the PR test pipeline needs a `if: always()` so
output is uploaded even in case of failures like https://github.com/xo/usql/actions/runs/11753817291 .

`if: always()` seems to be regularly used with actions/upload-artifact -
https://github.com/search?q=actions%2Fupload-artifact+always+path%3A.yml&type=code

The pipeline of the PR shows how it works in practice.