### PR TITLE
Fix substitution of quoted variables 

### DIFF
--- a/stmt/stmt.go
+++ b/stmt/stmt.go
@@ -228,6 +228,7 @@ parse:
 				z, ok, _ := unquote(v.Name, true)
 				if v.Defined = ok || v.Quote == '?'; v.Defined {
 					b.r, b.rlen = v.Substitute(b.r, z, ok)
+					i-- // account for removal of the :
 				}
 				if b.Len != 0 {
 					v.I += b.Len + 1


### PR DESCRIPTION
testcli.go failed before the fix and passes after it.
Also includes a fix to testcli.go itself.

Closes #505 .