### PR TITLE
Add default filters for sqlite3 metadata tables reader

### DIFF
--- a/drivers/sqlite3/sqshared/reader.go
+++ b/drivers/sqlite3/sqshared/reader.go
@@ -3,6 +3,7 @@ package sqshared
 import (
 	"database/sql"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/xo/usql/drivers"
@@ -125,8 +126,18 @@ FROM (
 		conds = append(conds, "table_name LIKE ?")
 	}
 	if len(f.Types) != 0 {
+		tableTypes := []string{
+			"BASE TABLE",
+			"TABLE",
+			"VIEW",
+			"GLOBAL TEMPORARY",
+		}
 		pholders := []string{}
 		for _, t := range f.Types {
+			if !slices.Contains(tableTypes, t) {
+				continue
+			}
+
 			vals = append(vals, t)
 			pholders = append(pholders, "?")
 		}

--- a/drivers/sqlite3/sqshared/reader_test.go
+++ b/drivers/sqlite3/sqshared/reader_test.go
@@ -141,7 +141,7 @@ func TestSchemas(t *testing.T) {
 }
 
 func TestTables(t *testing.T) {
-	result, err := reader.Tables(metadata.Filter{Types: []string{"BASE TABLE", "TABLE", "VIEW"}})
+	result, err := reader.Tables(metadata.Filter{Types: []string{"BASE TABLE", "TABLE", "VIEW", "GLOBAL TEMPORARY"}})
 	if err != nil {
 		log.Fatalf("Could not read tables: %v", err)
 	}


### PR DESCRIPTION
The current response from the metacmd `\dt` and `\dv' in `sqlite3` contains system tables, which is not expected. These changes add table types allowed in the result of the above metacmds.

Fixes #504 