### PR TITLE
fix: strip trailing semicolon in cosmosdb and unify implementation 

### DIFF
--- a/drivers/athena/athena.go
+++ b/drivers/athena/athena.go
@@ -5,22 +5,15 @@ package athena
 
 import (
 	"context"
-	"regexp"
 
 	_ "github.com/uber/athenadriver/go" // DRIVER: awsathena
-	"github.com/xo/dburl"
 	"github.com/xo/usql/drivers"
 )
 
 func init() {
-	endRE := regexp.MustCompile(`;?\s*$`)
 	drivers.Register("awsathena", drivers.Driver{
 		AllowMultilineComments: true,
-		Process: func(_ *dburl.URL, prefix string, sqlstr string) (string, string, bool, error) {
-			sqlstr = endRE.ReplaceAllString(sqlstr, "")
-			typ, q := drivers.QueryExecType(prefix, sqlstr)
-			return typ, sqlstr, q, nil
-		},
+		Process:                drivers.StripTrailingSemicolon,
 		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
 			err := db.QueryRowContext(

--- a/drivers/cosmos/cosmos.go
+++ b/drivers/cosmos/cosmos.go
@@ -9,5 +9,7 @@ import (
 )
 
 func init() {
-	drivers.Register("cosmos", drivers.Driver{})
+	drivers.Register("cosmos", drivers.Driver{
+		Process: drivers.StripTrailingSemicolon,
+	}, "gocosmos")
 }

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 	"unicode"
@@ -611,4 +612,12 @@ func CopyWithInsert(placeholder func(int) string) func(ctx context.Context, db *
 
 func init() {
 	dburl.OdbcIgnoreQueryPrefixes = []string{"usql_"}
+}
+
+var endRE = regexp.MustCompile(`;?\s*$`)
+
+func StripTrailingSemicolon(_ *dburl.URL, prefix string, sqlstr string) (string, string, bool, error) {
+	sqlstr = endRE.ReplaceAllString(sqlstr, "")
+	typ, q := QueryExecType(prefix, sqlstr)
+	return typ, sqlstr, q, nil
 }

--- a/drivers/presto/presto.go
+++ b/drivers/presto/presto.go
@@ -5,22 +5,15 @@ package presto
 
 import (
 	"context"
-	"regexp"
 
 	_ "github.com/prestodb/presto-go-client/presto" // DRIVER
-	"github.com/xo/dburl"
 	"github.com/xo/usql/drivers"
 )
 
 func init() {
-	endRE := regexp.MustCompile(`;?\s*$`)
 	drivers.Register("presto", drivers.Driver{
 		AllowMultilineComments: true,
-		Process: func(_ *dburl.URL, prefix string, sqlstr string) (string, string, bool, error) {
-			sqlstr = endRE.ReplaceAllString(sqlstr, "")
-			typ, q := drivers.QueryExecType(prefix, sqlstr)
-			return typ, sqlstr, q, nil
-		},
+		Process:                drivers.StripTrailingSemicolon,
 		Version: func(ctx context.Context, db drivers.DB) (string, error) {
 			var ver string
 			err := db.QueryRowContext(

--- a/drivers/sapase/sapase.go
+++ b/drivers/sapase/sapase.go
@@ -6,17 +6,14 @@ package sapase
 import (
 	"context"
 	"errors"
-	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/thda/tds" // DRIVER: tds
-	"github.com/xo/dburl"
 	"github.com/xo/usql/drivers"
 )
 
 func init() {
-	endRE := regexp.MustCompile(`;?\s*$`)
 	drivers.Register("tds", drivers.Driver{
 		AllowMultilineComments:  true,
 		RequirePreviousPassword: true,
@@ -49,10 +46,6 @@ func init() {
 		IsPasswordErr: func(err error) bool {
 			return strings.Contains(err.Error(), "Login failed")
 		},
-		Process: func(_ *dburl.URL, prefix string, sqlstr string) (string, string, bool, error) {
-			sqlstr = endRE.ReplaceAllString(sqlstr, "")
-			typ, q := drivers.QueryExecType(prefix, sqlstr)
-			return typ, sqlstr, q, nil
-		},
+		Process: drivers.StripTrailingSemicolon,
 	})
 }


### PR DESCRIPTION
Fixes, in part, #511 .

cosmosdb, like several other databases, needs trailing semicolons to be
removed from the statement before it is passed to the driver.

This fix applies that to cosmosdb and makes the other databases with identical
processing use the same implementation - presto, trino, athena, SAP ASE.

Drivers that strip trailing semicolon as part of other processing are
not included in the refactoring to keep scope small.

Testing: with https://github.com/xo/dburl/pull/44 applied , testing cosmosdb ...

![image](https://github.com/user-attachments/assets/558183a7-ead4-43ac-9718-3e1846820eb7)

Also tested with trino.