### PR TITLE
Fix all actual typos and use .codespellrc to skip others

### DIFF
--- a/README.md
+++ b/README.md
@@ -1468,7 +1468,7 @@ pg:booktest@=>
 ```
 
 While the `.usqlpass` functionality will not be removed, it is recommended to
-[define named connections][connection-vars] preferrably via [the `config.yaml`
+[define named connections][connection-vars] preferably via [the `config.yaml`
 file][config].
 
 <hr/>

--- a/drivers/metadata/informationschema/metadata.go
+++ b/drivers/metadata/informationschema/metadata.go
@@ -94,7 +94,7 @@ func New(opts ...metadata.ReaderOption) func(drivers.DB, ...metadata.ReaderOptio
 		systemSchemas:     []string{"information_schema"},
 		dataTypeFormatter: func(col metadata.Column) string { return col.DataType },
 	}
-	// aply InformationSchema specific options
+	// apply InformationSchema specific options
 	for _, o := range opts {
 		o(s)
 	}
@@ -929,7 +929,7 @@ func (s InformationSchema) PrivilegeSummaries(f metadata.Filter) (*metadata.Priv
 	}
 
 	// In the query result, table and column level privileges will be on separate rows.
-	// Each table or column can have multple privileges (i.e rows).
+	// Each table or column can have multiple privileges (i.e rows).
 	// For table level privileges the `column_name` column is empty.
 	qstr := "SELECT * FROM (\n" + strings.Join(qstrs, "\nUNION ALL\n") + "\n) AS subquery"
 	rows, closeRows, err := s.query(

--- a/drivers/metadata/postgres/metadata_test.go
+++ b/drivers/metadata/postgres/metadata_test.go
@@ -257,7 +257,7 @@ func TestIndexes(t *testing.T) {
 		for _, v := range tests {
 			result, err := r.Indexes(metadata.Filter{Name: fmt.Sprintf("%s_index", v.indexType)})
 			if err != nil {
-				log.Fatalf("Could not get Index informatin: %s", err)
+				log.Fatalf("Could not get Index information: %s", err)
 			}
 			for result.Next() {
 				accessMethods = append(accessMethods, result.Get().Type)
@@ -274,7 +274,7 @@ func TestIndexes(t *testing.T) {
 	t.Run("Get info about index access method for all table indexes.", func(t *testing.T) {
 		result, err := r.Indexes(metadata.Filter{Schema: schema, Parent: table})
 		if err != nil {
-			log.Fatalf("Could not get Index informatin: %s", err)
+			log.Fatalf("Could not get Index information: %s", err)
 		}
 		accessMethods := []string{}
 		for result.Next() {

--- a/drivers/metadata/reader.go
+++ b/drivers/metadata/reader.go
@@ -269,5 +269,5 @@ func (r LoggingReader) Query(q string, v ...interface{}) (*sql.Rows, CloseFunc, 
 	return rows, func() { rows.Close() }, err
 }
 
-// CloseFunc should be called when result wont be processed anymore
+// CloseFunc should be called when result won't be processed anymore
 type CloseFunc func()


### PR DESCRIPTION
Fix all spelling errors found by codespell[1] version 2.4.1.

No changes to `"ALTER HEIRARCHY"` in `drivers/qtype.go`.

[1] https://github.com/codespell-project/codespell/