### PR TITLE
Add different OS config file locations to conection examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,9 +546,6 @@ $ usql pg://
 See the relevant documentation [on database drivers][databases] for more
 information.
 
-You can set config file explicitly with `usql --config $PATH_TO_CONFIG_FILE` if your location differs 
-from the default ones.
-
 ### Connection Examples
 
 The following are example connection strings and additional ways to connect to


### PR DESCRIPTION
Add additional info for default config file locations in Connection Examples.
Add note for possibility of explicitly setting `usql --config` in section abount `config.yaml`