### PR TITLE
snowflake: allow $$ delimited strings

### DIFF
--- a/drivers/snowflake/snowflake.go
+++ b/drivers/snowflake/snowflake.go
@@ -29,6 +29,7 @@ func init() {
 	)
 	drivers.Register("snowflake", drivers.Driver{
 		AllowMultilineComments: true,
+		AllowDollar:            true,
 		Err: func(err error) (string, string) {
 			if e, ok := err.(*gosnowflake.SnowflakeError); ok {
 				return strconv.Itoa(e.Number), e.Message


### PR DESCRIPTION
Enable support for $$ delimited string literals in the snowflake driver.

This enables queries that would otherwise fail, like:

`select $$Hello 'world';$$;`