### PR TITLE
feat: add PROMPT2 support for multi-line query continuation

### DIFF
--- a/env/list.go
+++ b/env/list.go
@@ -102,6 +102,10 @@ var varNames = []varName{
 		`specifies the standard ` + text.CommandName + ` prompt`,
 	},
 	{
+		`PROMPT2`,
+		`specifies the continuation prompt for multi-line queries`,
+	},
+	{
 		`QUIET`,
 		`run quietly (same as -q option)`,
 	},

--- a/env/vars.go
+++ b/env/vars.go
@@ -90,6 +90,7 @@ func NewDefaultVars() *Variables {
 			"ON_ERROR_STOP":         "off",
 			// prompts
 			"PROMPT1": "%S%N%m%/%R%# ",
+			"PROMPT2": "  ",
 			// syntax highlighting variables
 			"SYNTAX_HL":             enableSyntaxHL,
 			"SYNTAX_HL_FORMAT":      colorLevel.ChromaFormatterName(),

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -72,6 +72,8 @@ type Handler struct {
 	singleLineMode bool
 	// buf is the query statement buffer.
 	buf *stmt.Stmt
+	// lastPromptWidth is the visual width of the last rendered PROMPT1, used by %w in PROMPT2.
+	lastPromptWidth int
 	// lastExec is the last executed query statement.
 	lastExec string
 	// lastExecPrefix is the last executed query statement prefix.
@@ -98,9 +100,26 @@ type Handler struct {
 
 // New creates a new input handler.
 func New(l rline.IO, user *user.User, wd string, charts billy.Filesystem, nopw bool) *Handler {
-	f, iactive := l.Next, l.Interactive()
+	iactive := l.Interactive()
+	h := &Handler{
+		l:      l,
+		user:   user,
+		wd:     wd,
+		charts: charts,
+		nopw:   nopw,
+	}
+	f := l.Next
 	if iactive {
 		f = func() ([]rune, error) {
+			// set prompt: PROMPT1 for new statements, PROMPT2 for continuation lines
+			var rendered string
+			if h.buf != nil && h.buf.Len != 0 {
+				rendered = h.Prompt(env.Get("PROMPT2"))
+			} else {
+				rendered = h.Prompt(env.Get("PROMPT1"))
+				h.lastPromptWidth = visualWidth(rendered)
+			}
+			l.Prompt(rendered)
 			// next line
 			r, err := l.Next()
 			if err != nil {
@@ -111,14 +130,7 @@ func New(l rline.IO, user *user.User, wd string, charts billy.Filesystem, nopw b
 			return r, nil
 		}
 	}
-	h := &Handler{
-		l:      l,
-		user:   user,
-		wd:     wd,
-		charts: charts,
-		nopw:   nopw,
-		buf:    stmt.New(f),
-	}
+	h.buf = stmt.New(f)
 	if iactive {
 		l.SetOutput(h.outputHighlighter)
 		l.Completer(completer.NewDefaultCompleter(completer.WithConnStrings(h.connStrings())))
@@ -165,10 +177,6 @@ func (h *Handler) Run() error {
 	var execute bool
 	for {
 		execute = false
-		// set prompt
-		if iactive {
-			h.l.Prompt(h.Prompt(env.Get("PROMPT1")))
-		}
 		// read next statement/command
 		switch cmd, paramstr, err = h.buf.Next(env.Untick(h.user, env.Vars(), false)); {
 		case h.singleLineMode && err == nil:
@@ -686,10 +694,22 @@ func (h *Handler) Prompt(prompt string) string {
 		case '`': // value of the evaluated command
 		case '[', ']':
 		case 'w':
+			buf = append(buf, strings.Repeat(" ", h.lastPromptWidth)...)
 		}
 		i++
 	}
 	return string(buf)
+}
+
+// ansiEscapeRE matches ANSI terminal escape sequences so they can be excluded
+// from visual-width calculations.
+var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+// visualWidth returns the number of visible characters in s, ignoring ANSI
+// escape sequences and the %[ / %] prompt markers usql strips elsewhere.
+func visualWidth(s string) int {
+	s = ansiEscapeRE.ReplaceAllString(s, "")
+	return len([]rune(s))
 }
 
 // IO returns the io for the handler.


### PR DESCRIPTION
## Summary

Implements `PROMPT2`, the continuation prompt shown on lines 2+ of a multi-line statement — matching psql behaviour.

- **Wires up PROMPT2**: moves prompt selection into the `f()` readline reader closure so it fires before each individual `readline` call. The previous approach set the prompt once per statement in `Run()`, but `stmt.Next()` reads all continuation lines internally before returning, so `PROMPT2` was never reached.
- **Default `PROMPT2` is `"  "`** (two spaces) — unobtrusive, no visual noise. Users who prefer aligned whitespace can set `\set PROMPT2 %w` in `~/.usqlrc`.
- **Implements `%w`**: outputs whitespace matching the visual width of the last rendered `PROMPT1`, stripping ANSI escape sequences. Adds `lastPromptWidth` to `Handler` and a `visualWidth()` helper.
- **Registers `PROMPT2`** in `env/vars.go` defaults and `env/list.go` `\? variables` help output.

## Test plan

- [x] Start usql against any database, paste a multi-line query — continuation lines show two spaces instead of the full prompt
- [x] `\set PROMPT2 %w` — continuation lines align with PROMPT1 width
- [x] `\set PROMPT2 ""` — no continuation prompt
- [x] `\? variables` lists PROMPT2

🤖 Generated with [Claude Code](https://claude.com/claude-code)