### PR TITLE
Fix golang vulns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xo/usql
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0


### PR DESCRIPTION
https://go.dev/doc/devel/release#go1.26.0

Use the latest golang version to fix the crypto vulns.